### PR TITLE
Add missing controller and service tests

### DIFF
--- a/cs-project.Tests/Controllers/FuelPriceControllerTests.cs
+++ b/cs-project.Tests/Controllers/FuelPriceControllerTests.cs
@@ -32,4 +32,30 @@ public class FuelPriceControllerTests
 
         Assert.IsType<CreatedAtActionResult>(result.Result);
     }
+
+    [Fact]
+    public async Task GetFuelPrice_ReturnsOk_WhenFound()
+    {
+        var service = new Mock<IFuelPriceService>();
+        service.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(new FuelPriceDTO { Id = 1 });
+        var controller = new FuelPriceController(service.Object);
+
+        var result = await controller.GetFuelPrice(1);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<FuelPriceDTO>(okResult.Value);
+        Assert.Equal(1, dto.Id);
+    }
+
+    [Fact]
+    public async Task CreateFuelPrice_ReturnsBadRequest_WhenModelInvalid()
+    {
+        var service = new Mock<IFuelPriceService>();
+        var controller = new FuelPriceController(service.Object);
+        controller.ModelState.AddModelError("FuelType", "Required");
+
+        var result = await controller.CreateFuelPrice(new FuelPriceCreateDTO());
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
 }

--- a/cs-project.Tests/Controllers/TransactionControllerTests.cs
+++ b/cs-project.Tests/Controllers/TransactionControllerTests.cs
@@ -22,6 +22,18 @@ public class TransactionControllerTests
     }
 
     [Fact]
+    public async Task UpdateTransaction_ReturnsNoContent_WhenTrue()
+    {
+        var service = new Mock<ITransactionService>();
+        service.Setup(s => s.UpdateAsync(1, It.IsAny<TransactionsCreateDTO>())).ReturnsAsync(true);
+        var controller = new TransactionController(service.Object);
+
+        var result = await controller.UpdateTransaction(1, new TransactionsCreateDTO());
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
     public async Task CreateTransaction_ReturnsCreated()
     {
         var service = new Mock<ITransactionService>();
@@ -31,5 +43,17 @@ public class TransactionControllerTests
         var result = await controller.CreateTransaction(new TransactionsCreateDTO());
 
         Assert.IsType<CreatedAtActionResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task DeleteTransaction_ReturnsNotFound_WhenServiceReturnsFalse()
+    {
+        var service = new Mock<ITransactionService>();
+        service.Setup(s => s.DeleteAsync(1)).ReturnsAsync(false);
+        var controller = new TransactionController(service.Object);
+
+        var result = await controller.DeleteTransaction(1);
+
+        Assert.IsType<NotFoundResult>(result);
     }
 }

--- a/cs-project.Tests/Services/FuelPriceServiceTests.cs
+++ b/cs-project.Tests/Services/FuelPriceServiceTests.cs
@@ -60,4 +60,14 @@ public class FuelPriceServiceTests
         repo.Verify();
         Assert.Equal("A", result.FuelType);
     }
+
+    [Fact]
+    public async Task CreateAsync_Throws_WhenRepositoryFails()
+    {
+        var repo = new Mock<IFuelPriceRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<FuelPrice>())).ThrowsAsync(new InvalidOperationException());
+        var service = new FuelPriceService(repo.Object, _mapper);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.CreateAsync(new FuelPriceCreateDTO()));
+    }
 }

--- a/cs-project/Controllers/FuelPriceController.cs
+++ b/cs-project/Controllers/FuelPriceController.cs
@@ -34,8 +34,10 @@ namespace cs_project.Controllers
         [HttpPost]
         public async Task<ActionResult<FuelPriceDTO>> CreateFuelPrice([FromBody] FuelPriceCreateDTO dto)
         {
+            if (!ModelState.IsValid) return BadRequest(ModelState);
+
             var createdPrice = await _fuelPriceService.CreateAsync(dto);
-            
+
             return CreatedAtAction(nameof(GetFuelPrice), new {id = createdPrice.Id}, createdPrice);
         }
 


### PR DESCRIPTION
## Summary
- add new controller unit tests for missing scenarios
- add exception test for `FuelPriceService`
- return BadRequest on invalid model state in `FuelPriceController`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6863e7e413fc832a8602f6febe89ebaf