### PR TITLE
Add FluentValidation validators for Create DTOs

### DIFF
--- a/cs-project/Program.cs
+++ b/cs-project/Program.cs
@@ -120,7 +120,7 @@ builder.Services.Configure<IdentityOptions>(options =>
     options.Lockout.MaxFailedAccessAttempts = 5;
     options.Lockout.AllowedForNewUsers = true;
 });
-builder.Services.AddValidatorsFromAssemblyContaining<PumpCreateDTOValidator>();
+builder.Services.AddValidatorsFromAssemblyContaining<AuditLogCreateDTOValidator>();
 
 builder.Services.AddAutoMapper(typeof(MappingProfile));
 

--- a/cs-project/Validators/AuditLogCreateDTOValidator.cs
+++ b/cs-project/Validators/AuditLogCreateDTOValidator.cs
@@ -1,0 +1,22 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class AuditLogCreateDTOValidator : AbstractValidator<AuditLogCreateDTO>
+{
+    public AuditLogCreateDTOValidator()
+    {
+        RuleFor(x => x.TableName)
+            .NotEmpty().WithMessage("Table name is required.")
+            .MaximumLength(100);
+        RuleFor(x => x.RecordId)
+            .GreaterThan(0);
+        RuleFor(x => x.Operation)
+            .NotEmpty().WithMessage("Operation is required.")
+            .MaximumLength(50);
+        RuleFor(x => x.ModifiedBy)
+            .GreaterThan(0);
+        RuleFor(x => x.ModifiedAt)
+            .NotEmpty();
+    }
+}

--- a/cs-project/Validators/CorrectionLogCreateDTOValidator.cs
+++ b/cs-project/Validators/CorrectionLogCreateDTOValidator.cs
@@ -1,0 +1,25 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class CorrectionLogCreateDTOValidator : AbstractValidator<CorrectionLogCreateDTO>
+{
+    public CorrectionLogCreateDTOValidator()
+    {
+        RuleFor(x => x.TargetTable)
+            .NotEmpty().WithMessage("Target table is required.")
+            .MaximumLength(100);
+        RuleFor(x => x.TargetId)
+            .GreaterThan(0);
+        RuleFor(x => x.Type)
+            .IsInEnum();
+        RuleFor(x => x.Reason)
+            .NotEmpty().WithMessage("Reason is required.");
+        RuleFor(x => x.RequestedById)
+            .GreaterThan(0);
+        RuleFor(x => x.ApprovedById)
+            .GreaterThan(0).When(x => x.ApprovedById.HasValue);
+        RuleFor(x => x.ApprovedAtUtc)
+            .GreaterThan(x => x.RequestedAtUtc).When(x => x.ApprovedAtUtc.HasValue);
+    }
+}

--- a/cs-project/Validators/CustomerPaymentCreateDTOValidator.cs
+++ b/cs-project/Validators/CustomerPaymentCreateDTOValidator.cs
@@ -1,0 +1,20 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class CustomerPaymentCreateDTOValidator : AbstractValidator<CustomerPaymentCreateDTO>
+{
+    public CustomerPaymentCreateDTOValidator()
+    {
+        RuleFor(x => x.CustomerTransactionId)
+            .GreaterThan(0);
+        RuleFor(x => x.Method)
+            .IsInEnum();
+        RuleFor(x => x.Amount)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.AuthorizationCode)
+            .MaximumLength(100).When(x => !string.IsNullOrEmpty(x.AuthorizationCode));
+        RuleFor(x => x.ProcessedAtUtc)
+            .NotEmpty();
+    }
+}

--- a/cs-project/Validators/CustomerTransactionCreateDTOValidator.cs
+++ b/cs-project/Validators/CustomerTransactionCreateDTOValidator.cs
@@ -1,0 +1,22 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class CustomerTransactionCreateDTOValidator : AbstractValidator<CustomerTransactionCreateDTO>
+{
+    public CustomerTransactionCreateDTOValidator()
+    {
+        RuleFor(x => x.PumpId)
+            .GreaterThan(0);
+        RuleFor(x => x.StationFuelPriceId)
+            .GreaterThan(0);
+        RuleFor(x => x.Liters)
+            .GreaterThan(0);
+        RuleFor(x => x.PricePerLiter)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.TotalPrice)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.TimestampUtc)
+            .NotEmpty();
+    }
+}

--- a/cs-project/Validators/EmployeeCreateDTOValidator.cs
+++ b/cs-project/Validators/EmployeeCreateDTOValidator.cs
@@ -1,0 +1,22 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class EmployeeCreateDTOValidator : AbstractValidator<EmployeeCreateDTO>
+{
+    public EmployeeCreateDTOValidator()
+    {
+        RuleFor(x => x.StationId)
+            .GreaterThan(0).When(x => x.StationId.HasValue);
+        RuleFor(x => x.FirstName)
+            .NotEmpty().WithMessage("First name is required.")
+            .MaximumLength(100);
+        RuleFor(x => x.LastName)
+            .NotEmpty().WithMessage("Last name is required.")
+            .MaximumLength(100);
+        RuleFor(x => x.Role)
+            .IsInEnum();
+        RuleFor(x => x.HireDateUtc)
+            .NotEmpty();
+    }
+}

--- a/cs-project/Validators/ExchangeRateCreateDTOValidator.cs
+++ b/cs-project/Validators/ExchangeRateCreateDTOValidator.cs
@@ -1,0 +1,20 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class ExchangeRateCreateDTOValidator : AbstractValidator<ExchangeRateCreateDTO>
+{
+    public ExchangeRateCreateDTOValidator()
+    {
+        RuleFor(x => x.BaseCurrency)
+            .NotEmpty().Length(3);
+        RuleFor(x => x.QuoteCurrency)
+            .NotEmpty().Length(3);
+        RuleFor(x => x.Rate)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.RetrievedAtUtc)
+            .NotEmpty();
+        RuleFor(x => x.Source)
+            .MaximumLength(100).When(x => !string.IsNullOrEmpty(x.Source));
+    }
+}

--- a/cs-project/Validators/PricePolicyCreateDTOValidator.cs
+++ b/cs-project/Validators/PricePolicyCreateDTOValidator.cs
@@ -1,0 +1,32 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class PricePolicyCreateDTOValidator : AbstractValidator<PricePolicyCreateDTO>
+{
+    public PricePolicyCreateDTOValidator()
+    {
+        RuleFor(x => x.StationId)
+            .GreaterThan(0).When(x => x.StationId.HasValue);
+        RuleFor(x => x.FuelType)
+            .IsInEnum();
+        RuleFor(x => x.Method)
+            .IsInEnum();
+        RuleFor(x => x.BaseUsdPrice)
+            .GreaterThanOrEqualTo(0).When(x => x.BaseUsdPrice.HasValue);
+        RuleFor(x => x.MarginPct)
+            .GreaterThanOrEqualTo(0).When(x => x.MarginPct.HasValue);
+        RuleFor(x => x.MarginRon)
+            .GreaterThanOrEqualTo(0).When(x => x.MarginRon.HasValue);
+        RuleFor(x => x.RoundingIncrement)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.RoundingMode)
+            .IsInEnum();
+        RuleFor(x => x.EffectiveFromUtc)
+            .NotEmpty();
+        RuleFor(x => x.EffectiveToUtc)
+            .GreaterThan(x => x.EffectiveFromUtc).When(x => x.EffectiveToUtc.HasValue);
+        RuleFor(x => x.Priority)
+            .GreaterThanOrEqualTo(0);
+    }
+}

--- a/cs-project/Validators/ShiftCreateDTOValidator.cs
+++ b/cs-project/Validators/ShiftCreateDTOValidator.cs
@@ -1,0 +1,18 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class ShiftCreateDTOValidator : AbstractValidator<ShiftCreateDTO>
+{
+    public ShiftCreateDTOValidator()
+    {
+        RuleFor(x => x.StationId)
+            .GreaterThan(0);
+        RuleFor(x => x.StartUtc)
+            .NotEmpty();
+        RuleFor(x => x.EndUtc)
+            .GreaterThan(x => x.StartUtc);
+        RuleFor(x => x.TotalSalesAmount)
+            .GreaterThanOrEqualTo(0);
+    }
+}

--- a/cs-project/Validators/ShiftEmployeeCreateDTOValidator.cs
+++ b/cs-project/Validators/ShiftEmployeeCreateDTOValidator.cs
@@ -1,0 +1,13 @@
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class ShiftEmployeeCreateDTOValidator : AbstractValidator<ShiftEmployeeCreateDTO>
+{
+    public ShiftEmployeeCreateDTOValidator()
+    {
+        RuleFor(x => x.ShiftId)
+            .GreaterThan(0);
+        RuleFor(x => x.EmployeeId)
+            .GreaterThan(0);
+    }
+}

--- a/cs-project/Validators/StationCreateDTOValidator.cs
+++ b/cs-project/Validators/StationCreateDTOValidator.cs
@@ -1,0 +1,19 @@
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class StationCreateDTOValidator : AbstractValidator<StationCreateDTO>
+{
+    public StationCreateDTOValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Name is required.")
+            .MaximumLength(200);
+        RuleFor(x => x.Address)
+            .NotEmpty().WithMessage("Address is required.")
+            .MaximumLength(200);
+        RuleFor(x => x.City)
+            .MaximumLength(100).When(x => !string.IsNullOrEmpty(x.City));
+        RuleFor(x => x.Country)
+            .MaximumLength(100).When(x => !string.IsNullOrEmpty(x.Country));
+    }
+}

--- a/cs-project/Validators/StationFuelPriceCreateDTOValidator.cs
+++ b/cs-project/Validators/StationFuelPriceCreateDTOValidator.cs
@@ -1,0 +1,28 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class StationFuelPriceCreateDTOValidator : AbstractValidator<StationFuelPriceCreateDTO>
+{
+    public StationFuelPriceCreateDTOValidator()
+    {
+        RuleFor(x => x.StationId)
+            .GreaterThan(0);
+        RuleFor(x => x.FuelType)
+            .IsInEnum();
+        RuleFor(x => x.PriceRon)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.EffectiveFromUtc)
+            .NotEmpty();
+        RuleFor(x => x.EffectiveToUtc)
+            .GreaterThan(x => x.EffectiveFromUtc).When(x => x.EffectiveToUtc.HasValue);
+        RuleFor(x => x.DerivedFromPolicyId)
+            .GreaterThan(0).When(x => x.DerivedFromPolicyId.HasValue);
+        RuleFor(x => x.FxRateUsed)
+            .GreaterThanOrEqualTo(0).When(x => x.FxRateUsed.HasValue);
+        RuleFor(x => x.CostRonUsed)
+            .GreaterThanOrEqualTo(0).When(x => x.CostRonUsed.HasValue);
+        RuleFor(x => x.CreatedByEmployeeId)
+            .GreaterThan(0).When(x => x.CreatedByEmployeeId.HasValue);
+    }
+}

--- a/cs-project/Validators/SupplierCreateDTOValidator.cs
+++ b/cs-project/Validators/SupplierCreateDTOValidator.cs
@@ -1,0 +1,23 @@
+using cs_project.Core.DTOs;
+using FluentValidation;
+using System.ComponentModel.DataAnnotations;
+
+public class SupplierCreateDTOValidator : AbstractValidator<SupplierCreateDTO>
+{
+    public SupplierCreateDTOValidator()
+    {
+        RuleFor(x => x.CompanyName)
+            .NotEmpty().WithMessage("Company name is required.")
+            .MaximumLength(200);
+        RuleFor(x => x.ContactPerson)
+            .MaximumLength(100).When(x => !string.IsNullOrEmpty(x.ContactPerson));
+        RuleFor(x => x.Phone)
+            .Must(phone => new PhoneAttribute().IsValid(phone!))
+            .When(x => !string.IsNullOrEmpty(x.Phone))
+            .WithMessage("Phone is not valid.");
+        RuleFor(x => x.Email)
+            .EmailAddress().When(x => !string.IsNullOrEmpty(x.Email));
+        RuleFor(x => x.TaxRegistrationNumber)
+            .MaximumLength(50).When(x => !string.IsNullOrEmpty(x.TaxRegistrationNumber));
+    }
+}

--- a/cs-project/Validators/SupplierInvoiceCreateDTOValidator.cs
+++ b/cs-project/Validators/SupplierInvoiceCreateDTOValidator.cs
@@ -1,0 +1,20 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class SupplierInvoiceCreateDTOValidator : AbstractValidator<SupplierInvoiceCreateDTO>
+{
+    public SupplierInvoiceCreateDTOValidator()
+    {
+        RuleFor(x => x.SupplierId)
+            .GreaterThan(0);
+        RuleFor(x => x.StationId)
+            .GreaterThan(0);
+        RuleFor(x => x.DeliveryDateUtc)
+            .NotEmpty();
+        RuleFor(x => x.Currency)
+            .NotEmpty().Length(3);
+        RuleFor(x => x.FxToRon)
+            .GreaterThanOrEqualTo(0);
+    }
+}

--- a/cs-project/Validators/SupplierInvoiceLineCreateDTOValidator.cs
+++ b/cs-project/Validators/SupplierInvoiceLineCreateDTOValidator.cs
@@ -1,0 +1,19 @@
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class SupplierInvoiceLineCreateDTOValidator : AbstractValidator<SupplierInvoiceLineCreateDTO>
+{
+    public SupplierInvoiceLineCreateDTOValidator()
+    {
+        RuleFor(x => x.SupplierInvoiceId)
+            .GreaterThan(0);
+        RuleFor(x => x.TankId)
+            .GreaterThan(0);
+        RuleFor(x => x.FuelType)
+            .IsInEnum();
+        RuleFor(x => x.QuantityLiters)
+            .GreaterThan(0);
+        RuleFor(x => x.UnitPrice)
+            .GreaterThanOrEqualTo(0);
+    }
+}

--- a/cs-project/Validators/SupplierPaymentApplyCreateDTOValidator.cs
+++ b/cs-project/Validators/SupplierPaymentApplyCreateDTOValidator.cs
@@ -1,0 +1,15 @@
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class SupplierPaymentApplyCreateDTOValidator : AbstractValidator<SupplierPaymentApplyCreateDTO>
+{
+    public SupplierPaymentApplyCreateDTOValidator()
+    {
+        RuleFor(x => x.SupplierPaymentId)
+            .GreaterThan(0);
+        RuleFor(x => x.SupplierInvoiceId)
+            .GreaterThan(0);
+        RuleFor(x => x.AppliedAmount)
+            .GreaterThanOrEqualTo(0);
+    }
+}

--- a/cs-project/Validators/SupplierPaymentCreateDTOValidator.cs
+++ b/cs-project/Validators/SupplierPaymentCreateDTOValidator.cs
@@ -1,0 +1,18 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class SupplierPaymentCreateDTOValidator : AbstractValidator<SupplierPaymentCreateDTO>
+{
+    public SupplierPaymentCreateDTOValidator()
+    {
+        RuleFor(x => x.SupplierId)
+            .GreaterThan(0);
+        RuleFor(x => x.Method)
+            .IsInEnum();
+        RuleFor(x => x.Amount)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.PaidAtUtc)
+            .NotEmpty();
+    }
+}

--- a/cs-project/Validators/TankCreateDTOValidator.cs
+++ b/cs-project/Validators/TankCreateDTOValidator.cs
@@ -1,0 +1,21 @@
+using System;
+using cs_project.Core.DTOs;
+using FluentValidation;
+
+public class TankCreateDTOValidator : AbstractValidator<TankCreateDTO>
+{
+    public TankCreateDTOValidator()
+    {
+        RuleFor(x => x.StationId)
+            .GreaterThan(0);
+        RuleFor(x => x.FuelType)
+            .IsInEnum();
+        RuleFor(x => x.CapacityLiters)
+            .GreaterThanOrEqualTo(0);
+        RuleFor(x => x.CurrentVolumeLiters)
+            .GreaterThanOrEqualTo(0)
+            .LessThanOrEqualTo(x => x.CapacityLiters);
+        RuleFor(x => x.LastRefilledAtUtc)
+            .LessThanOrEqualTo(DateTime.UtcNow).When(x => x.LastRefilledAtUtc.HasValue);
+    }
+}


### PR DESCRIPTION
## Summary
- implement FluentValidation validators for all *CreateDTO types
- register validators via AddValidatorsFromAssemblyContaining

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a730a4dc34832a9ee8baad77d7fe90