### PR TITLE
Add supplier invoice and line CRUD controllers

### DIFF
--- a/cs-project.Core/Interfaces/ISupplierInvoiceLineRepository.cs
+++ b/cs-project.Core/Interfaces/ISupplierInvoiceLineRepository.cs
@@ -8,6 +8,7 @@ namespace cs_project.Infrastructure.Repositories
         Task<(IEnumerable<SupplierInvoiceLine> Items, int TotalCount)> QuerySupplierInvoiceLinesAsync(PagingQueryParameters query);
         Task<IEnumerable<SupplierInvoiceLine>> GetAllAsync();
         Task<SupplierInvoiceLine?> GetByIdAsync(int id);
+        Task<IEnumerable<SupplierInvoiceLine>> GetByInvoiceIdAsync(int invoiceId);
         Task AddAsync(SupplierInvoiceLine line);
         void Update(SupplierInvoiceLine line);
         void Delete(SupplierInvoiceLine line);

--- a/cs-project.Core/Interfaces/ISupplierInvoiceLineService.cs
+++ b/cs-project.Core/Interfaces/ISupplierInvoiceLineService.cs
@@ -8,6 +8,7 @@ namespace cs_project.Infrastructure.Services
         Task<PagedResult<SupplierInvoiceLineDTO>> GetSupplierInvoiceLineAsync(PagingQueryParameters query);
         Task<IEnumerable<SupplierInvoiceLineDTO>> GetAllSupplierInvoiceLinesAsync();
         Task<SupplierInvoiceLineDTO?> GetSupplierInvoiceLineByIdAsync(int id);
+        Task<IEnumerable<SupplierInvoiceLineDTO>> GetLinesByInvoiceIdAsync(int invoiceId);
         Task<SupplierInvoiceLineDTO> CreateSupplierInvoiceLineAsync(SupplierInvoiceLineCreateDTO dto);
         Task<bool> UpdateSupplierInvoiceLineAsync(int id, SupplierInvoiceLineCreateDTO dto);
         Task<bool> DeleteSupplierInvoiceLineAsync(int id);

--- a/cs-project.Infrastructure/Repositories/SupplierInvoiceLineRepository.cs
+++ b/cs-project.Infrastructure/Repositories/SupplierInvoiceLineRepository.cs
@@ -1,0 +1,56 @@
+using cs_project.Core.Entities;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace cs_project.Infrastructure.Repositories;
+
+public class SupplierInvoiceLineRepository : ISupplierInvoiceLineRepository
+{
+    private readonly AppDbContext _db;
+
+    public SupplierInvoiceLineRepository(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<(IEnumerable<SupplierInvoiceLine> Items, int TotalCount)> QuerySupplierInvoiceLinesAsync(PagingQueryParameters query)
+    {
+        var lines = _db.SupplierInvoiceLines.AsNoTracking();
+
+        lines = query.SortBy?.ToLower() switch
+        {
+            "fueltype_desc" => lines.OrderByDescending(l => l.FuelType),
+            "fueltype" => lines.OrderBy(l => l.FuelType),
+            _ => lines.OrderBy(l => l.Id)
+        };
+
+        int totalCount = await lines.CountAsync();
+        int page = query.Page > 0 ? query.Page : 1;
+        int pageSize = query.PageSize > 0 && query.PageSize <= 100 ? query.PageSize : 20;
+        lines = lines.Skip((page - 1) * pageSize).Take(pageSize);
+        var items = await lines.ToListAsync();
+        return (items, totalCount);
+    }
+
+    public async Task<IEnumerable<SupplierInvoiceLine>> GetAllAsync() =>
+        await _db.SupplierInvoiceLines.AsNoTracking().ToListAsync();
+
+    public async Task<SupplierInvoiceLine?> GetByIdAsync(int id) =>
+        await _db.SupplierInvoiceLines.FindAsync(id);
+
+    public async Task<IEnumerable<SupplierInvoiceLine>> GetByInvoiceIdAsync(int invoiceId) =>
+        await _db.SupplierInvoiceLines.Where(l => l.SupplierInvoiceId == invoiceId).AsNoTracking().ToListAsync();
+
+    public async Task AddAsync(SupplierInvoiceLine line) =>
+        await _db.SupplierInvoiceLines.AddAsync(line);
+
+    public void Update(SupplierInvoiceLine line) =>
+        _db.SupplierInvoiceLines.Update(line);
+
+    public void Delete(SupplierInvoiceLine line) =>
+        _db.SupplierInvoiceLines.Remove(line);
+
+    public async Task<bool> SaveChangesAsync() =>
+        await _db.SaveChangesAsync() > 0;
+}

--- a/cs-project.Infrastructure/Repositories/SupplierInvoiceRepository.cs
+++ b/cs-project.Infrastructure/Repositories/SupplierInvoiceRepository.cs
@@ -1,0 +1,53 @@
+using cs_project.Core.Entities;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace cs_project.Infrastructure.Repositories;
+
+public class SupplierInvoiceRepository : ISupplierInvoiceRepository
+{
+    private readonly AppDbContext _db;
+
+    public SupplierInvoiceRepository(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<(IEnumerable<SupplierInvoice> Items, int TotalCount)> QuerySupplierInvoicesAsync(PagingQueryParameters query)
+    {
+        var invoices = _db.SupplierInvoices.AsNoTracking();
+
+        invoices = query.SortBy?.ToLower() switch
+        {
+            "deliverydate_desc" => invoices.OrderByDescending(i => i.DeliveryDateUtc),
+            "deliverydate" => invoices.OrderBy(i => i.DeliveryDateUtc),
+            _ => invoices.OrderBy(i => i.Id)
+        };
+
+        int totalCount = await invoices.CountAsync();
+        int page = query.Page > 0 ? query.Page : 1;
+        int pageSize = query.PageSize > 0 && query.PageSize <= 100 ? query.PageSize : 20;
+        invoices = invoices.Skip((page - 1) * pageSize).Take(pageSize);
+        var items = await invoices.ToListAsync();
+        return (items, totalCount);
+    }
+
+    public async Task<IEnumerable<SupplierInvoice>> GetAllAsync() =>
+        await _db.SupplierInvoices.AsNoTracking().ToListAsync();
+
+    public async Task<SupplierInvoice?> GetByIdAsync(int id) =>
+        await _db.SupplierInvoices.FindAsync(id);
+
+    public async Task AddAsync(SupplierInvoice invoice) =>
+        await _db.SupplierInvoices.AddAsync(invoice);
+
+    public void Update(SupplierInvoice invoice) =>
+        _db.SupplierInvoices.Update(invoice);
+
+    public void Delete(SupplierInvoice invoice) =>
+        _db.SupplierInvoices.Remove(invoice);
+
+    public async Task<bool> SaveChangesAsync() =>
+        await _db.SaveChangesAsync() > 0;
+}

--- a/cs-project.Infrastructure/Services/SupplierInvoiceLineService.cs
+++ b/cs-project.Infrastructure/Services/SupplierInvoiceLineService.cs
@@ -1,0 +1,90 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Core.Models;
+
+namespace cs_project.Infrastructure.Services;
+
+public class SupplierInvoiceLineService : ISupplierInvoiceLineService
+{
+    private readonly ISupplierInvoiceLineRepository _lineRepository;
+    private readonly ISupplierInvoiceRepository _invoiceRepository;
+    private readonly ITankRepository _tankRepository;
+    private readonly IMapper _mapper;
+
+    public SupplierInvoiceLineService(ISupplierInvoiceLineRepository lineRepository,
+        ISupplierInvoiceRepository invoiceRepository,
+        ITankRepository tankRepository,
+        IMapper mapper)
+    {
+        _lineRepository = lineRepository;
+        _invoiceRepository = invoiceRepository;
+        _tankRepository = tankRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<PagedResult<SupplierInvoiceLineDTO>> GetSupplierInvoiceLineAsync(PagingQueryParameters query)
+    {
+        var (entities, total) = await _lineRepository.QuerySupplierInvoiceLinesAsync(query);
+        var dtoList = _mapper.Map<IEnumerable<SupplierInvoiceLineDTO>>(entities);
+        return new PagedResult<SupplierInvoiceLineDTO>
+        {
+            Items = dtoList,
+            TotalCount = total,
+            Page = query.Page,
+            PageSize = query.PageSize
+        };
+    }
+
+    public async Task<IEnumerable<SupplierInvoiceLineDTO>> GetAllSupplierInvoiceLinesAsync()
+    {
+        var lines = await _lineRepository.GetAllAsync();
+        return _mapper.Map<IEnumerable<SupplierInvoiceLineDTO>>(lines);
+    }
+
+    public async Task<SupplierInvoiceLineDTO?> GetSupplierInvoiceLineByIdAsync(int id)
+    {
+        var line = await _lineRepository.GetByIdAsync(id);
+        return line == null ? null : _mapper.Map<SupplierInvoiceLineDTO>(line);
+    }
+
+    public async Task<IEnumerable<SupplierInvoiceLineDTO>> GetLinesByInvoiceIdAsync(int invoiceId)
+    {
+        var lines = await _lineRepository.GetByInvoiceIdAsync(invoiceId);
+        return _mapper.Map<IEnumerable<SupplierInvoiceLineDTO>>(lines);
+    }
+
+    public async Task<SupplierInvoiceLineDTO> CreateSupplierInvoiceLineAsync(SupplierInvoiceLineCreateDTO dto)
+    {
+        if (await _invoiceRepository.GetByIdAsync(dto.SupplierInvoiceId) == null)
+            throw new KeyNotFoundException("SupplierInvoice not found");
+        if (await _tankRepository.GetByIdAsync(dto.TankId) == null)
+            throw new KeyNotFoundException("Tank not found");
+
+        var line = _mapper.Map<SupplierInvoiceLine>(dto);
+        await _lineRepository.AddAsync(line);
+        await _lineRepository.SaveChangesAsync();
+        return _mapper.Map<SupplierInvoiceLineDTO>(line);
+    }
+
+    public async Task<bool> UpdateSupplierInvoiceLineAsync(int id, SupplierInvoiceLineCreateDTO dto)
+    {
+        var line = await _lineRepository.GetByIdAsync(id);
+        if (line == null) return false;
+        if (await _invoiceRepository.GetByIdAsync(dto.SupplierInvoiceId) == null) return false;
+        if (await _tankRepository.GetByIdAsync(dto.TankId) == null) return false;
+
+        _mapper.Map(dto, line);
+        _lineRepository.Update(line);
+        return await _lineRepository.SaveChangesAsync();
+    }
+
+    public async Task<bool> DeleteSupplierInvoiceLineAsync(int id)
+    {
+        var line = await _lineRepository.GetByIdAsync(id);
+        if (line == null) return false;
+        _lineRepository.Delete(line);
+        return await _lineRepository.SaveChangesAsync();
+    }
+}

--- a/cs-project.Infrastructure/Services/SupplierInvoiceService.cs
+++ b/cs-project.Infrastructure/Services/SupplierInvoiceService.cs
@@ -1,0 +1,84 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Core.Models;
+
+namespace cs_project.Infrastructure.Services;
+
+public class SupplierInvoiceService : ISupplierInvoiceService
+{
+    private readonly ISupplierInvoiceRepository _invoiceRepository;
+    private readonly ISupplierRepository _supplierRepository;
+    private readonly IStationRepository _stationRepository;
+    private readonly IMapper _mapper;
+
+    public SupplierInvoiceService(ISupplierInvoiceRepository invoiceRepository,
+        ISupplierRepository supplierRepository,
+        IStationRepository stationRepository,
+        IMapper mapper)
+    {
+        _invoiceRepository = invoiceRepository;
+        _supplierRepository = supplierRepository;
+        _stationRepository = stationRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<PagedResult<SupplierInvoiceDTO>> GetSupplierInvoiceAsync(PagingQueryParameters query)
+    {
+        var (entities, total) = await _invoiceRepository.QuerySupplierInvoicesAsync(query);
+        var dtoList = _mapper.Map<IEnumerable<SupplierInvoiceDTO>>(entities);
+        return new PagedResult<SupplierInvoiceDTO>
+        {
+            Items = dtoList,
+            TotalCount = total,
+            Page = query.Page,
+            PageSize = query.PageSize
+        };
+    }
+
+    public async Task<IEnumerable<SupplierInvoiceDTO>> GetAllSupplierInvoicesAsync()
+    {
+        var invoices = await _invoiceRepository.GetAllAsync();
+        return _mapper.Map<IEnumerable<SupplierInvoiceDTO>>(invoices);
+    }
+
+    public async Task<SupplierInvoiceDTO?> GetSupplierInvoiceByIdAsync(int id)
+    {
+        var invoice = await _invoiceRepository.GetByIdAsync(id);
+        return invoice == null ? null : _mapper.Map<SupplierInvoiceDTO>(invoice);
+    }
+
+    public async Task<SupplierInvoiceDTO> CreateSupplierInvoiceAsync(SupplierInvoiceCreateDTO dto)
+    {
+        if (await _supplierRepository.GetByIdAsync(dto.SupplierId) == null)
+            throw new KeyNotFoundException("Supplier not found");
+        if (await _stationRepository.GetByIdAsync(dto.StationId) == null)
+            throw new KeyNotFoundException("Station not found");
+
+        var invoice = _mapper.Map<SupplierInvoice>(dto);
+        await _invoiceRepository.AddAsync(invoice);
+        await _invoiceRepository.SaveChangesAsync();
+        return _mapper.Map<SupplierInvoiceDTO>(invoice);
+    }
+
+    public async Task<bool> UpdateSupplierInvoiceAsync(int id, SupplierInvoiceCreateDTO dto)
+    {
+        var invoice = await _invoiceRepository.GetByIdAsync(id);
+        if (invoice == null) return false;
+        if (await _supplierRepository.GetByIdAsync(dto.SupplierId) == null) return false;
+        if (await _stationRepository.GetByIdAsync(dto.StationId) == null) return false;
+
+        _mapper.Map(dto, invoice);
+        _invoiceRepository.Update(invoice);
+        return await _invoiceRepository.SaveChangesAsync();
+    }
+
+    public async Task<bool> DeleteSupplierInvoiceAsync(int id)
+    {
+        var invoice = await _invoiceRepository.GetByIdAsync(id);
+        if (invoice == null) return false;
+        _invoiceRepository.Delete(invoice);
+        return await _invoiceRepository.SaveChangesAsync();
+    }
+}

--- a/cs-project.Tests/Controllers/SupplierInvoiceLinesControllerTests.cs
+++ b/cs-project.Tests/Controllers/SupplierInvoiceLinesControllerTests.cs
@@ -1,0 +1,37 @@
+using cs_project.Controllers;
+using cs_project.Core.DTOs;
+using cs_project.Infrastructure.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace cs_project.Tests.Controllers;
+
+public class SupplierInvoiceLinesControllerTests
+{
+    [Fact]
+    public async Task GetLine_ReturnsNotFound_WhenNull()
+    {
+        var service = new Mock<ISupplierInvoiceLineService>();
+        var logger = new Mock<ILogger<SupplierInvoiceLineController>>();
+        service.Setup(s => s.GetSupplierInvoiceLineByIdAsync(1)).ReturnsAsync((SupplierInvoiceLineDTO?)null);
+        var controller = new SupplierInvoiceLineController(service.Object, logger.Object);
+
+        var result = await controller.GetLine(1);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task DeleteLine_ReturnsNoContent()
+    {
+        var service = new Mock<ISupplierInvoiceLineService>();
+        var logger = new Mock<ILogger<SupplierInvoiceLineController>>();
+        service.Setup(s => s.DeleteSupplierInvoiceLineAsync(1)).ReturnsAsync(true);
+        var controller = new SupplierInvoiceLineController(service.Object, logger.Object);
+
+        var result = await controller.DeleteLine(1);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+}

--- a/cs-project.Tests/Controllers/SupplierInvoicesControllerTests.cs
+++ b/cs-project.Tests/Controllers/SupplierInvoicesControllerTests.cs
@@ -1,0 +1,39 @@
+using cs_project.Controllers;
+using cs_project.Core.DTOs;
+using cs_project.Infrastructure.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace cs_project.Tests.Controllers;
+
+public class SupplierInvoicesControllerTests
+{
+    [Fact]
+    public async Task GetInvoice_ReturnsNotFound_WhenNull()
+    {
+        var service = new Mock<ISupplierInvoiceService>();
+        var lineService = new Mock<ISupplierInvoiceLineService>();
+        var logger = new Mock<ILogger<SupplierInvoiceController>>();
+        service.Setup(s => s.GetSupplierInvoiceByIdAsync(1)).ReturnsAsync((SupplierInvoiceDTO?)null);
+        var controller = new SupplierInvoiceController(service.Object, lineService.Object, logger.Object);
+
+        var result = await controller.GetInvoice(1);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task DeleteInvoice_ReturnsNoContent()
+    {
+        var service = new Mock<ISupplierInvoiceService>();
+        var lineService = new Mock<ISupplierInvoiceLineService>();
+        var logger = new Mock<ILogger<SupplierInvoiceController>>();
+        service.Setup(s => s.DeleteSupplierInvoiceAsync(1)).ReturnsAsync(true);
+        var controller = new SupplierInvoiceController(service.Object, lineService.Object, logger.Object);
+
+        var result = await controller.DeleteInvoice(1);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+}

--- a/cs-project.Tests/Services/SupplierInvoiceLineServiceTests.cs
+++ b/cs-project.Tests/Services/SupplierInvoiceLineServiceTests.cs
@@ -1,0 +1,51 @@
+using AutoMapper;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+using static cs_project.Core.Entities.Enums;
+
+namespace cs_project.Tests.Services;
+
+public class SupplierInvoiceLineServiceTests
+{
+    private readonly IMapper _mapper;
+    public SupplierInvoiceLineServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetLineById_ReturnsDto()
+    {
+        var repo = new Mock<ISupplierInvoiceLineRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new SupplierInvoiceLine { Id = 1, SupplierInvoiceId = 1, TankId = 1, FuelType = FuelType.Diesel });
+        var invoiceRepo = new Mock<ISupplierInvoiceRepository>();
+        var tankRepo = new Mock<ITankRepository>();
+        var service = new SupplierInvoiceLineService(repo.Object, invoiceRepo.Object, tankRepo.Object, _mapper);
+
+        var result = await service.GetSupplierInvoiceLineByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task DeleteLineAsync_CallsRepository()
+    {
+        var line = new SupplierInvoiceLine { Id = 1, SupplierInvoiceId = 1, TankId = 1, FuelType = FuelType.Diesel };
+        var repo = new Mock<ISupplierInvoiceLineRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(line);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var invoiceRepo = new Mock<ISupplierInvoiceRepository>();
+        var tankRepo = new Mock<ITankRepository>();
+        var service = new SupplierInvoiceLineService(repo.Object, invoiceRepo.Object, tankRepo.Object, _mapper);
+
+        var result = await service.DeleteSupplierInvoiceLineAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(line), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/SupplierInvoiceServiceTests.cs
+++ b/cs-project.Tests/Services/SupplierInvoiceServiceTests.cs
@@ -1,0 +1,51 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class SupplierInvoiceServiceTests
+{
+    private readonly IMapper _mapper;
+    public SupplierInvoiceServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetInvoiceById_ReturnsDto()
+    {
+        var repo = new Mock<ISupplierInvoiceRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new SupplierInvoice { Id = 1, SupplierId = 1, StationId = 1, DeliveryDateUtc = DateTime.UtcNow });
+        var supplierRepo = new Mock<ISupplierRepository>();
+        var stationRepo = new Mock<IStationRepository>();
+        var service = new SupplierInvoiceService(repo.Object, supplierRepo.Object, stationRepo.Object, _mapper);
+
+        var result = await service.GetSupplierInvoiceByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task DeleteInvoiceAsync_CallsRepository()
+    {
+        var invoice = new SupplierInvoice { Id = 1, SupplierId = 1, StationId = 1, DeliveryDateUtc = DateTime.UtcNow };
+        var repo = new Mock<ISupplierInvoiceRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(invoice);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var supplierRepo = new Mock<ISupplierRepository>();
+        var stationRepo = new Mock<IStationRepository>();
+        var service = new SupplierInvoiceService(repo.Object, supplierRepo.Object, stationRepo.Object, _mapper);
+
+        var result = await service.DeleteSupplierInvoiceAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(invoice), Times.Once);
+    }
+}

--- a/cs-project/Controllers/SupplierInvoiceController.cs
+++ b/cs-project/Controllers/SupplierInvoiceController.cs
@@ -1,0 +1,79 @@
+using cs_project.Core.DTOs;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace cs_project.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Authorize]
+public class SupplierInvoiceController : ControllerBase
+{
+    private readonly ILogger<SupplierInvoiceController> _logger;
+    private readonly ISupplierInvoiceService _invoiceService;
+    private readonly ISupplierInvoiceLineService _lineService;
+
+    public SupplierInvoiceController(ISupplierInvoiceService invoiceService,
+        ISupplierInvoiceLineService lineService,
+        ILogger<SupplierInvoiceController> logger)
+    {
+        _logger = logger;
+        _invoiceService = invoiceService;
+        _lineService = lineService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<SupplierInvoiceDTO>>> GetAllInvoices()
+    {
+        var invoices = await _invoiceService.GetAllSupplierInvoicesAsync();
+        return Ok(invoices);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<SupplierInvoiceDTO>> GetInvoice(int id)
+    {
+        var invoice = await _invoiceService.GetSupplierInvoiceByIdAsync(id);
+        if (invoice == null) return NotFound();
+        return Ok(invoice);
+    }
+
+    [HttpGet("{id}/lines")]
+    public async Task<ActionResult<IEnumerable<SupplierInvoiceLineDTO>>> GetInvoiceLines(int id)
+    {
+        var invoice = await _invoiceService.GetSupplierInvoiceByIdAsync(id);
+        if (invoice == null) return NotFound();
+        var lines = await _lineService.GetLinesByInvoiceIdAsync(id);
+        return Ok(lines);
+    }
+
+    [HttpGet("query")]
+    public async Task<ActionResult<PagedResult<SupplierInvoiceDTO>>> QueryInvoices([FromQuery] PagingQueryParameters query)
+    {
+        var result = await _invoiceService.GetSupplierInvoiceAsync(query);
+        Response.Headers.Append("X-Total-Count", result.TotalCount.ToString());
+        return Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<SupplierInvoiceDTO>> CreateInvoice([FromBody] SupplierInvoiceCreateDTO dto)
+    {
+        var created = await _invoiceService.CreateSupplierInvoiceAsync(dto);
+        return CreatedAtAction(nameof(GetInvoice), new { id = created.Id }, created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateInvoice(int id, [FromBody] SupplierInvoiceCreateDTO dto)
+    {
+        var updated = await _invoiceService.UpdateSupplierInvoiceAsync(id, dto);
+        return updated ? NoContent() : NotFound();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteInvoice(int id)
+    {
+        var deleted = await _invoiceService.DeleteSupplierInvoiceAsync(id);
+        return deleted ? NoContent() : NotFound();
+    }
+}

--- a/cs-project/Controllers/SupplierInvoiceLineController.cs
+++ b/cs-project/Controllers/SupplierInvoiceLineController.cs
@@ -1,0 +1,66 @@
+using cs_project.Core.DTOs;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace cs_project.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Authorize]
+public class SupplierInvoiceLineController : ControllerBase
+{
+    private readonly ILogger<SupplierInvoiceLineController> _logger;
+    private readonly ISupplierInvoiceLineService _lineService;
+
+    public SupplierInvoiceLineController(ISupplierInvoiceLineService lineService, ILogger<SupplierInvoiceLineController> logger)
+    {
+        _logger = logger;
+        _lineService = lineService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<SupplierInvoiceLineDTO>>> GetAllLines()
+    {
+        var lines = await _lineService.GetAllSupplierInvoiceLinesAsync();
+        return Ok(lines);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<SupplierInvoiceLineDTO>> GetLine(int id)
+    {
+        var line = await _lineService.GetSupplierInvoiceLineByIdAsync(id);
+        if (line == null) return NotFound();
+        return Ok(line);
+    }
+
+    [HttpGet("query")]
+    public async Task<ActionResult<PagedResult<SupplierInvoiceLineDTO>>> QueryLines([FromQuery] PagingQueryParameters query)
+    {
+        var result = await _lineService.GetSupplierInvoiceLineAsync(query);
+        Response.Headers.Append("X-Total-Count", result.TotalCount.ToString());
+        return Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<SupplierInvoiceLineDTO>> CreateLine([FromBody] SupplierInvoiceLineCreateDTO dto)
+    {
+        var created = await _lineService.CreateSupplierInvoiceLineAsync(dto);
+        return CreatedAtAction(nameof(GetLine), new { id = created.Id }, created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateLine(int id, [FromBody] SupplierInvoiceLineCreateDTO dto)
+    {
+        var updated = await _lineService.UpdateSupplierInvoiceLineAsync(id, dto);
+        return updated ? NoContent() : NotFound();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteLine(int id)
+    {
+        var deleted = await _lineService.DeleteSupplierInvoiceLineAsync(id);
+        return deleted ? NoContent() : NotFound();
+    }
+}

--- a/cs-project/Program.cs
+++ b/cs-project/Program.cs
@@ -171,6 +171,12 @@ builder.Services.AddScoped<IShiftEmployeeService, ShiftEmployeeService>();
 builder.Services.AddScoped<ISupplierRepository, SupplierRepository>();
 builder.Services.AddScoped<ISupplierService, SupplierService>();
 
+builder.Services.AddScoped<ISupplierInvoiceRepository, SupplierInvoiceRepository>();
+builder.Services.AddScoped<ISupplierInvoiceService, SupplierInvoiceService>();
+
+builder.Services.AddScoped<ISupplierInvoiceLineRepository, SupplierInvoiceLineRepository>();
+builder.Services.AddScoped<ISupplierInvoiceLineService, SupplierInvoiceLineService>();
+
 builder.Services.AddScoped<IStationFuelPriceRepository, StationFuelPriceRepository>();
 
 builder.Services.AddScoped<ISalesService, SalesService>();


### PR DESCRIPTION
## Summary
- implement SupplierInvoice and SupplierInvoiceLine repositories and services
- add API controllers for supplier invoices and their lines with CRUD endpoints and line listing
- register new services and ensure invoice line creation checks supplier and tank references