### PR TITLE
Add read-only audit and correction log controllers

### DIFF
--- a/cs-project.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/cs-project.Infrastructure/Repositories/AuditLogRepository.cs
@@ -1,0 +1,68 @@
+using cs_project.Core.Entities.Audit;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace cs_project.Infrastructure.Repositories
+{
+    public class AuditLogRepository : IAuditLogRepository
+    {
+        private readonly AppDbContext _db;
+
+        public AuditLogRepository(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<(IEnumerable<AuditLog> Items, int TotalCount)> QueryAuditLogsAsync(PagingQueryParameters query)
+        {
+            var logs = _db.AuditLogs.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+            {
+                var term = query.SearchTerm.ToLower();
+                logs = logs.Where(l =>
+                    l.TableName.ToLower().Contains(term) ||
+                    l.Operation.ToLower().Contains(term) ||
+                    l.CorrelationId.ToString().ToLower().Contains(term));
+            }
+
+            logs = query.SortBy?.ToLower() switch
+            {
+                "tablename" => logs.OrderBy(l => l.TableName),
+                "tablename_desc" => logs.OrderByDescending(l => l.TableName),
+                "modifiedat" => logs.OrderBy(l => l.ModifiedAt),
+                "modifiedat_desc" => logs.OrderByDescending(l => l.ModifiedAt),
+                _ => logs.OrderByDescending(l => l.Id)
+            };
+
+            int totalCount = await logs.CountAsync();
+
+            int page = query.Page > 0 ? query.Page : 1;
+            int pageSize = query.PageSize > 0 && query.PageSize <= 100 ? query.PageSize : 20;
+            logs = logs.Skip((page - 1) * pageSize).Take(pageSize);
+
+            var items = await logs.ToListAsync();
+            return (items, totalCount);
+        }
+
+        public async Task<IEnumerable<AuditLog>> GetAllAsync() =>
+            await _db.AuditLogs.AsNoTracking().ToListAsync();
+
+        public async Task<AuditLog?> GetByIdAsync(long id) =>
+            await _db.AuditLogs.FindAsync(id);
+
+        public async Task AddAsync(AuditLog log) =>
+            await _db.AuditLogs.AddAsync(log);
+
+        public void Update(AuditLog log) =>
+            _db.AuditLogs.Update(log);
+
+        public void Delete(AuditLog log) =>
+            _db.AuditLogs.Remove(log);
+
+        public async Task<bool> SaveChangesAsync() =>
+            await _db.SaveChangesAsync() > 0;
+    }
+}
+

--- a/cs-project.Infrastructure/Repositories/CorrectionLogRepository.cs
+++ b/cs-project.Infrastructure/Repositories/CorrectionLogRepository.cs
@@ -1,0 +1,68 @@
+using cs_project.Core.Entities;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace cs_project.Infrastructure.Repositories
+{
+    public class CorrectionLogRepository : ICorrectionLogRepository
+    {
+        private readonly AppDbContext _db;
+
+        public CorrectionLogRepository(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<(IEnumerable<CorrectionLog> Items, int TotalCount)> QueryCorrectionLogsAsync(PagingQueryParameters query)
+        {
+            var logs = _db.CorrectionLogs.AsNoTracking();
+
+            if (!string.IsNullOrWhiteSpace(query.SearchTerm))
+            {
+                var term = query.SearchTerm.ToLower();
+                logs = logs.Where(l =>
+                    l.TargetTable.ToLower().Contains(term) ||
+                    l.Reason.ToLower().Contains(term) ||
+                    l.Type.ToString().ToLower().Contains(term));
+            }
+
+            logs = query.SortBy?.ToLower() switch
+            {
+                "targettable" => logs.OrderBy(l => l.TargetTable),
+                "targettable_desc" => logs.OrderByDescending(l => l.TargetTable),
+                "requestedatutc" => logs.OrderBy(l => l.RequestedAtUtc),
+                "requestedatutc_desc" => logs.OrderByDescending(l => l.RequestedAtUtc),
+                _ => logs.OrderByDescending(l => l.Id)
+            };
+
+            int totalCount = await logs.CountAsync();
+
+            int page = query.Page > 0 ? query.Page : 1;
+            int pageSize = query.PageSize > 0 && query.PageSize <= 100 ? query.PageSize : 20;
+            logs = logs.Skip((page - 1) * pageSize).Take(pageSize);
+
+            var items = await logs.ToListAsync();
+            return (items, totalCount);
+        }
+
+        public async Task<IEnumerable<CorrectionLog>> GetAllAsync() =>
+            await _db.CorrectionLogs.AsNoTracking().ToListAsync();
+
+        public async Task<CorrectionLog?> GetByIdAsync(int id) =>
+            await _db.CorrectionLogs.FindAsync(id);
+
+        public async Task AddAsync(CorrectionLog log) =>
+            await _db.CorrectionLogs.AddAsync(log);
+
+        public void Update(CorrectionLog log) =>
+            _db.CorrectionLogs.Update(log);
+
+        public void Delete(CorrectionLog log) =>
+            _db.CorrectionLogs.Remove(log);
+
+        public async Task<bool> SaveChangesAsync() =>
+            await _db.SaveChangesAsync() > 0;
+    }
+}
+

--- a/cs-project.Infrastructure/Services/AuditLogService.cs
+++ b/cs-project.Infrastructure/Services/AuditLogService.cs
@@ -1,0 +1,74 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities.Audit;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Repositories;
+
+namespace cs_project.Infrastructure.Services
+{
+    public class AuditLogService : IAuditLogService
+    {
+        private readonly IAuditLogRepository _auditLogRepository;
+        private readonly IMapper _mapper;
+
+        public AuditLogService(IAuditLogRepository auditLogRepository, IMapper mapper)
+        {
+            _auditLogRepository = auditLogRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<PagedResult<AuditLogDTO>> GetAuditLogAsync(PagingQueryParameters query)
+        {
+            var (entities, total) = await _auditLogRepository.QueryAuditLogsAsync(query);
+            var dtoList = _mapper.Map<IEnumerable<AuditLogDTO>>(entities);
+
+            return new PagedResult<AuditLogDTO>
+            {
+                Items = dtoList,
+                TotalCount = total,
+                Page = query.Page,
+                PageSize = query.PageSize
+            };
+        }
+
+        public async Task<IEnumerable<AuditLogDTO>> GetAllAuditLogsAsync()
+        {
+            var logs = await _auditLogRepository.GetAllAsync();
+            return _mapper.Map<IEnumerable<AuditLogDTO>>(logs);
+        }
+
+        public async Task<AuditLogDTO?> GetAuditLogByIdAsync(long id)
+        {
+            var log = await _auditLogRepository.GetByIdAsync(id);
+            return log == null ? null : _mapper.Map<AuditLogDTO>(log);
+        }
+
+        public async Task<AuditLogDTO> CreateAuditLogAsync(AuditLogCreateDTO dto)
+        {
+            var log = _mapper.Map<AuditLog>(dto);
+            await _auditLogRepository.AddAsync(log);
+            await _auditLogRepository.SaveChangesAsync();
+            return _mapper.Map<AuditLogDTO>(log);
+        }
+
+        public async Task<bool> UpdateAuditLogAsync(long id, AuditLogCreateDTO dto)
+        {
+            var log = await _auditLogRepository.GetByIdAsync(id);
+            if (log == null) return false;
+
+            _mapper.Map(dto, log);
+            _auditLogRepository.Update(log);
+            return await _auditLogRepository.SaveChangesAsync();
+        }
+
+        public async Task<bool> DeleteAuditLogAsync(long id)
+        {
+            var log = await _auditLogRepository.GetByIdAsync(id);
+            if (log == null) return false;
+
+            _auditLogRepository.Delete(log);
+            return await _auditLogRepository.SaveChangesAsync();
+        }
+    }
+}
+

--- a/cs-project.Infrastructure/Services/CorrectionLogService.cs
+++ b/cs-project.Infrastructure/Services/CorrectionLogService.cs
@@ -1,0 +1,74 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Repositories;
+
+namespace cs_project.Infrastructure.Services
+{
+    public class CorrectionLogService : ICorrectionLogService
+    {
+        private readonly ICorrectionLogRepository _correctionLogRepository;
+        private readonly IMapper _mapper;
+
+        public CorrectionLogService(ICorrectionLogRepository correctionLogRepository, IMapper mapper)
+        {
+            _correctionLogRepository = correctionLogRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<PagedResult<CorrectionLogDTO>> GetCorrectionLogAsync(PagingQueryParameters query)
+        {
+            var (entities, total) = await _correctionLogRepository.QueryCorrectionLogsAsync(query);
+            var dtoList = _mapper.Map<IEnumerable<CorrectionLogDTO>>(entities);
+
+            return new PagedResult<CorrectionLogDTO>
+            {
+                Items = dtoList,
+                TotalCount = total,
+                Page = query.Page,
+                PageSize = query.PageSize
+            };
+        }
+
+        public async Task<IEnumerable<CorrectionLogDTO>> GetAllCorrectionLogsAsync()
+        {
+            var logs = await _correctionLogRepository.GetAllAsync();
+            return _mapper.Map<IEnumerable<CorrectionLogDTO>>(logs);
+        }
+
+        public async Task<CorrectionLogDTO?> GetCorrectionLogByIdAsync(int id)
+        {
+            var log = await _correctionLogRepository.GetByIdAsync(id);
+            return log == null ? null : _mapper.Map<CorrectionLogDTO>(log);
+        }
+
+        public async Task<CorrectionLogDTO> CreateCorrectionLogAsync(CorrectionLogCreateDTO dto)
+        {
+            var log = _mapper.Map<CorrectionLog>(dto);
+            await _correctionLogRepository.AddAsync(log);
+            await _correctionLogRepository.SaveChangesAsync();
+            return _mapper.Map<CorrectionLogDTO>(log);
+        }
+
+        public async Task<bool> UpdateCorrectionLogAsync(int id, CorrectionLogCreateDTO dto)
+        {
+            var log = await _correctionLogRepository.GetByIdAsync(id);
+            if (log == null) return false;
+
+            _mapper.Map(dto, log);
+            _correctionLogRepository.Update(log);
+            return await _correctionLogRepository.SaveChangesAsync();
+        }
+
+        public async Task<bool> DeleteCorrectionLogAsync(int id)
+        {
+            var log = await _correctionLogRepository.GetByIdAsync(id);
+            if (log == null) return false;
+
+            _correctionLogRepository.Delete(log);
+            return await _correctionLogRepository.SaveChangesAsync();
+        }
+    }
+}
+

--- a/cs-project/Controllers/AuditLogController.cs
+++ b/cs-project/Controllers/AuditLogController.cs
@@ -1,0 +1,45 @@
+using cs_project.Core.DTOs;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace cs_project.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [Authorize(Policy = "ViewAuditLogs")]
+    public class AuditLogController : ControllerBase
+    {
+        private readonly IAuditLogService _auditLogService;
+
+        public AuditLogController(IAuditLogService auditLogService)
+        {
+            _auditLogService = auditLogService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<AuditLogDTO>>> GetAllAuditLogs()
+        {
+            var logs = await _auditLogService.GetAllAuditLogsAsync();
+            return Ok(logs);
+        }
+
+        [HttpGet("{id:long}")]
+        public async Task<ActionResult<AuditLogDTO>> GetAuditLog(long id)
+        {
+            var log = await _auditLogService.GetAuditLogByIdAsync(id);
+            if (log == null) return NotFound();
+            return Ok(log);
+        }
+
+        [HttpGet("query")]
+        public async Task<ActionResult<PagedResult<AuditLogDTO>>> QueryAuditLogs([FromQuery] PagingQueryParameters query)
+        {
+            var result = await _auditLogService.GetAuditLogAsync(query);
+            Response.Headers.Append("X-Total-Count", result.TotalCount.ToString());
+            return Ok(result);
+        }
+    }
+}
+

--- a/cs-project/Controllers/CorrectionLogController.cs
+++ b/cs-project/Controllers/CorrectionLogController.cs
@@ -1,0 +1,45 @@
+using cs_project.Core.DTOs;
+using cs_project.Core.Models;
+using cs_project.Infrastructure.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace cs_project.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [Authorize(Policy = "ViewCorrectionLogs")]
+    public class CorrectionLogController : ControllerBase
+    {
+        private readonly ICorrectionLogService _correctionLogService;
+
+        public CorrectionLogController(ICorrectionLogService correctionLogService)
+        {
+            _correctionLogService = correctionLogService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<CorrectionLogDTO>>> GetAllCorrectionLogs()
+        {
+            var logs = await _correctionLogService.GetAllCorrectionLogsAsync();
+            return Ok(logs);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<CorrectionLogDTO>> GetCorrectionLog(int id)
+        {
+            var log = await _correctionLogService.GetCorrectionLogByIdAsync(id);
+            if (log == null) return NotFound();
+            return Ok(log);
+        }
+
+        [HttpGet("query")]
+        public async Task<ActionResult<PagedResult<CorrectionLogDTO>>> QueryCorrectionLogs([FromQuery] PagingQueryParameters query)
+        {
+            var result = await _correctionLogService.GetCorrectionLogAsync(query);
+            Response.Headers.Append("X-Total-Count", result.TotalCount.ToString());
+            return Ok(result);
+        }
+    }
+}
+

--- a/cs-project/Program.cs
+++ b/cs-project/Program.cs
@@ -108,7 +108,11 @@ builder.Services.AddAuthentication(options =>
 });
 
 
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("ViewAuditLogs", policy => policy.RequireRole("Admin"));
+    options.AddPolicy("ViewCorrectionLogs", policy => policy.RequireRole("Admin"));
+});
 
 builder.Services.ConfigureApplicationCookie(options =>
 {
@@ -149,6 +153,11 @@ builder.Services.Configure<IdentityOptions>(options =>
 builder.Services.AddValidatorsFromAssemblyContaining<AuditLogCreateDTOValidator>();
 
 builder.Services.AddAutoMapper(typeof(MappingProfile));
+
+builder.Services.AddScoped<IAuditLogRepository, AuditLogRepository>();
+builder.Services.AddScoped<IAuditLogService, AuditLogService>();
+builder.Services.AddScoped<ICorrectionLogRepository, CorrectionLogRepository>();
+builder.Services.AddScoped<ICorrectionLogService, CorrectionLogService>();
 
 builder.Services.AddScoped<IPumpRepository, PumpRepository>();
 builder.Services.AddScoped<IPumpService, PumpService>();


### PR DESCRIPTION
## Summary
- implement repositories and services for audit and correction logs with paging and search
- add read-only controllers for audit and correction logs protected by authorization policies
- wire up new services and policies in Program setup

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ac580d5dc0832a8c0f9150cf49d0a9