### PR TITLE
Add repository CRUD tests using in-memory context

### DIFF
--- a/cs-project.Tests/Repositories/EmployeeRepositoryTests.cs
+++ b/cs-project.Tests/Repositories/EmployeeRepositoryTests.cs
@@ -1,0 +1,129 @@
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Data;
+using cs_project.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using static cs_project.Core.Entities.Enums;
+
+namespace cs_project.Tests.Repositories;
+
+public class EmployeeRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+        var ctx = new AppDbContext(options);
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static Station SeedStation(AppDbContext ctx)
+    {
+        var station = new Station { Id = 1, Name = "Main", Address = "Addr" };
+        ctx.Stations.Add(station);
+        ctx.SaveChanges();
+        return station;
+    }
+
+    [Fact]
+    public async Task AddAndFetchEmployee_Works()
+    {
+        using var ctx = CreateContext();
+        var repo = new EmployeeRepository(ctx);
+        var station = SeedStation(ctx);
+        var employee = new Employee
+        {
+            Id = 1,
+            FirstName = "John",
+            LastName = "Doe",
+            Role = EmployeeRole.Cashier,
+            HireDateUtc = DateTime.UtcNow,
+            StationId = station.Id
+        };
+
+        await repo.AddAsync(employee);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.NotNull(fetched);
+        Assert.Equal("John", fetched!.FirstName);
+    }
+
+    [Fact]
+    public async Task UpdateEmployee_PersistsChanges()
+    {
+        using var ctx = CreateContext();
+        var repo = new EmployeeRepository(ctx);
+        var station = SeedStation(ctx);
+        var employee = new Employee
+        {
+            Id = 1,
+            FirstName = "John",
+            LastName = "Doe",
+            Role = EmployeeRole.Cashier,
+            HireDateUtc = DateTime.UtcNow,
+            StationId = station.Id
+        };
+        await repo.AddAsync(employee);
+        await repo.SaveChangesAsync();
+
+        employee.LastName = "Smith";
+        repo.Update(employee);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Equal("Smith", fetched!.LastName);
+    }
+
+    [Fact]
+    public async Task DeleteEmployee_RemovesEntity()
+    {
+        using var ctx = CreateContext();
+        var repo = new EmployeeRepository(ctx);
+        var station = SeedStation(ctx);
+        var employee = new Employee
+        {
+            Id = 1,
+            FirstName = "John",
+            LastName = "Doe",
+            Role = EmployeeRole.Cashier,
+            HireDateUtc = DateTime.UtcNow,
+            StationId = station.Id
+        };
+        await repo.AddAsync(employee);
+        await repo.SaveChangesAsync();
+
+        repo.Delete(employee);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task GetById_Missing_ReturnsNull()
+    {
+        using var ctx = CreateContext();
+        var repo = new EmployeeRepository(ctx);
+        var fetched = await repo.GetByIdAsync(999);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task AddEmployee_MissingNames_Throws()
+    {
+        using var ctx = CreateContext();
+        var repo = new EmployeeRepository(ctx);
+        var employee = new Employee
+        {
+            Id = 1,
+            FirstName = null!,
+            LastName = null!,
+            Role = EmployeeRole.Cashier,
+            HireDateUtc = DateTime.UtcNow
+        };
+        await repo.AddAsync(employee);
+        await Assert.ThrowsAsync<DbUpdateException>(repo.SaveChangesAsync);
+    }
+}
+

--- a/cs-project.Tests/Repositories/StationRepositoryTests.cs
+++ b/cs-project.Tests/Repositories/StationRepositoryTests.cs
@@ -1,0 +1,86 @@
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Data;
+using cs_project.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace cs_project.Tests.Repositories;
+
+public class StationRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+        var ctx = new AppDbContext(options);
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AddAndFetchStation_Works()
+    {
+        using var ctx = CreateContext();
+        var repo = new StationRepository(ctx);
+        var station = new Station { Id = 1, Name = "Main", Address = "Addr" };
+
+        await repo.AddAsync(station);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.NotNull(fetched);
+        Assert.Equal("Main", fetched!.Name);
+    }
+
+    [Fact]
+    public async Task UpdateStation_PersistsChanges()
+    {
+        using var ctx = CreateContext();
+        var repo = new StationRepository(ctx);
+        var station = new Station { Id = 1, Name = "Main", Address = "Addr" };
+        await repo.AddAsync(station);
+        await repo.SaveChangesAsync();
+
+        station.Name = "Updated";
+        repo.Update(station);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Equal("Updated", fetched!.Name);
+    }
+
+    [Fact]
+    public async Task DeleteStation_RemovesEntity()
+    {
+        using var ctx = CreateContext();
+        var repo = new StationRepository(ctx);
+        var station = new Station { Id = 1, Name = "Main", Address = "Addr" };
+        await repo.AddAsync(station);
+        await repo.SaveChangesAsync();
+
+        repo.Delete(station);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task GetById_Missing_ReturnsNull()
+    {
+        using var ctx = CreateContext();
+        var repo = new StationRepository(ctx);
+        var fetched = await repo.GetByIdAsync(123);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task AddStation_MissingName_Throws()
+    {
+        using var ctx = CreateContext();
+        var repo = new StationRepository(ctx);
+        var station = new Station { Id = 1, Name = null!, Address = "Addr" };
+        await repo.AddAsync(station);
+        await Assert.ThrowsAsync<DbUpdateException>(repo.SaveChangesAsync);
+    }
+}
+

--- a/cs-project.Tests/Repositories/SupplierRepositoryTests.cs
+++ b/cs-project.Tests/Repositories/SupplierRepositoryTests.cs
@@ -1,0 +1,86 @@
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Data;
+using cs_project.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace cs_project.Tests.Repositories;
+
+public class SupplierRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+        var ctx = new AppDbContext(options);
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AddAndFetchSupplier_Works()
+    {
+        using var ctx = CreateContext();
+        var repo = new SupplierRepository(ctx);
+        var supplier = new Supplier { Id = 1, CompanyName = "Acme" };
+
+        await repo.AddAsync(supplier);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.NotNull(fetched);
+        Assert.Equal("Acme", fetched!.CompanyName);
+    }
+
+    [Fact]
+    public async Task UpdateSupplier_PersistsChanges()
+    {
+        using var ctx = CreateContext();
+        var repo = new SupplierRepository(ctx);
+        var supplier = new Supplier { Id = 1, CompanyName = "Acme" };
+        await repo.AddAsync(supplier);
+        await repo.SaveChangesAsync();
+
+        supplier.CompanyName = "Updated";
+        repo.Update(supplier);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Equal("Updated", fetched!.CompanyName);
+    }
+
+    [Fact]
+    public async Task DeleteSupplier_RemovesEntity()
+    {
+        using var ctx = CreateContext();
+        var repo = new SupplierRepository(ctx);
+        var supplier = new Supplier { Id = 1, CompanyName = "Acme" };
+        await repo.AddAsync(supplier);
+        await repo.SaveChangesAsync();
+
+        repo.Delete(supplier);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task GetById_Missing_ReturnsNull()
+    {
+        using var ctx = CreateContext();
+        var repo = new SupplierRepository(ctx);
+        var fetched = await repo.GetByIdAsync(123);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task AddSupplier_MissingCompanyName_Throws()
+    {
+        using var ctx = CreateContext();
+        var repo = new SupplierRepository(ctx);
+        var supplier = new Supplier { Id = 1, CompanyName = null! };
+        await repo.AddAsync(supplier);
+        await Assert.ThrowsAsync<DbUpdateException>(repo.SaveChangesAsync);
+    }
+}
+

--- a/cs-project.Tests/Repositories/TankRepositoryTests.cs
+++ b/cs-project.Tests/Repositories/TankRepositoryTests.cs
@@ -1,0 +1,105 @@
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Data;
+using cs_project.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using static cs_project.Core.Entities.Enums;
+
+namespace cs_project.Tests.Repositories;
+
+public class TankRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+        var ctx = new AppDbContext(options);
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static Station SeedStation(AppDbContext ctx)
+    {
+        var station = new Station { Id = 1, Name = "Main", Address = "Addr" };
+        ctx.Stations.Add(station);
+        ctx.SaveChanges();
+        return station;
+    }
+
+    [Fact]
+    public async Task AddAndFetchTank_Works()
+    {
+        using var ctx = CreateContext();
+        var repo = new TankRepository(ctx);
+        var station = SeedStation(ctx);
+        var tank = new Tank { Id = 1, StationId = station.Id, Station = station, FuelType = FuelType.Diesel };
+
+        await repo.AddAsync(tank);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.NotNull(fetched);
+        Assert.Equal(FuelType.Diesel, fetched!.FuelType);
+    }
+
+    [Fact]
+    public async Task UpdateTank_PersistsChanges()
+    {
+        using var ctx = CreateContext();
+        var repo = new TankRepository(ctx);
+        var station = SeedStation(ctx);
+        var tank = new Tank { Id = 1, StationId = station.Id, Station = station, FuelType = FuelType.Diesel };
+        await repo.AddAsync(tank);
+        await repo.SaveChangesAsync();
+
+        tank.FuelType = FuelType.LPG;
+        repo.Update(tank);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Equal(FuelType.LPG, fetched!.FuelType);
+    }
+
+    [Fact]
+    public async Task DeleteTank_RemovesEntity()
+    {
+        using var ctx = CreateContext();
+        var repo = new TankRepository(ctx);
+        var station = SeedStation(ctx);
+        var tank = new Tank { Id = 1, StationId = station.Id, Station = station, FuelType = FuelType.Diesel };
+        await repo.AddAsync(tank);
+        await repo.SaveChangesAsync();
+
+        repo.Delete(tank);
+        await repo.SaveChangesAsync();
+
+        var fetched = await repo.GetByIdAsync(1);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task GetById_Missing_ReturnsNull()
+    {
+        using var ctx = CreateContext();
+        var repo = new TankRepository(ctx);
+        var fetched = await repo.GetByIdAsync(123);
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task AddTank_DuplicateKey_Throws()
+    {
+        using var ctx = CreateContext();
+        var repo = new TankRepository(ctx);
+        var station = SeedStation(ctx);
+        var tank1 = new Tank { Id = 1, StationId = station.Id, Station = station, FuelType = FuelType.Diesel };
+        await repo.AddAsync(tank1);
+        await repo.SaveChangesAsync();
+
+        var tank2 = new Tank { Id = 1, StationId = station.Id, Station = station, FuelType = FuelType.LPG };
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await repo.AddAsync(tank2);
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CRUD and error behavior tests for StationRepository
- add CRUD and error behavior tests for TankRepository
- add CRUD and error behavior tests for SupplierRepository
- add CRUD and error behavior tests for EmployeeRepository

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5d6089a8832a851e29f44a90fd28