### PR TITLE
Add unit tests for remaining services

### DIFF
--- a/cs-project.Tests/Services/AuditLogServiceTests.cs
+++ b/cs-project.Tests/Services/AuditLogServiceTests.cs
@@ -1,0 +1,61 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities.Audit;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class AuditLogServiceTests
+{
+    private readonly IMapper _mapper;
+
+    public AuditLogServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<IAuditLogRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new AuditLog { Id = 1 });
+        var service = new AuditLogService(repo.Object, _mapper);
+
+        var result = await service.GetAuditLogByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<IAuditLogRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((AuditLog?)null);
+        var service = new AuditLogService(repo.Object, _mapper);
+
+        var result = await service.GetAuditLogByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new AuditLog { Id = 1 };
+        var repo = new Mock<IAuditLogRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var service = new AuditLogService(repo.Object, _mapper);
+
+        var result = await service.DeleteAuditLogAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/CorrectionLogServiceTests.cs
+++ b/cs-project.Tests/Services/CorrectionLogServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class CorrectionLogServiceTests
+{
+    private readonly IMapper _mapper;
+    public CorrectionLogServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<ICorrectionLogRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new CorrectionLog { Id = 1 });
+        var service = new CorrectionLogService(repo.Object, _mapper);
+
+        var result = await service.GetCorrectionLogByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<ICorrectionLogRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((CorrectionLog?)null);
+        var service = new CorrectionLogService(repo.Object, _mapper);
+
+        var result = await service.GetCorrectionLogByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new CorrectionLog { Id = 1 };
+        var repo = new Mock<ICorrectionLogRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var service = new CorrectionLogService(repo.Object, _mapper);
+
+        var result = await service.DeleteCorrectionLogAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/CustomerTransactionServiceTests.cs
+++ b/cs-project.Tests/Services/CustomerTransactionServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class CustomerTransactionServiceTests
+{
+    private readonly IMapper _mapper;
+    public CustomerTransactionServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<ICustomerTransactionRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new CustomerTransaction { Id = 1 });
+        var service = new CustomerTransactionService(repo.Object, _mapper);
+
+        var result = await service.GetCustomerTransactionByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<ICustomerTransactionRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((CustomerTransaction?)null);
+        var service = new CustomerTransactionService(repo.Object, _mapper);
+
+        var result = await service.GetCustomerTransactionByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new CustomerTransaction { Id = 1 };
+        var repo = new Mock<ICustomerTransactionRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var service = new CustomerTransactionService(repo.Object, _mapper);
+
+        var result = await service.DeleteCustomerTransactionAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/ExchangeRateServiceTests.cs
+++ b/cs-project.Tests/Services/ExchangeRateServiceTests.cs
@@ -1,0 +1,58 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities.Pricing;
+using cs_project.Core.Interfaces;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class ExchangeRateServiceTests
+{
+    private readonly IMapper _mapper;
+    public ExchangeRateServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<IExchangeRateRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(new ExchangeRate { Id = 1, BaseCurrency="USD", QuoteCurrency="RON" });
+        var service = new ExchangeRateService(repo.Object, _mapper);
+
+        var result = await service.GetByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<IExchangeRateRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync((ExchangeRate?)null);
+        var service = new ExchangeRateService(repo.Object, _mapper);
+        var result = await service.GetByIdAsync(1);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new ExchangeRate { Id = 1, BaseCurrency="USD", QuoteCurrency="RON" };
+        var repo = new Mock<IExchangeRateRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true).Verifiable();
+        var service = new ExchangeRateService(repo.Object, _mapper);
+
+        var result = await service.DeleteAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/PricePolicyServiceTests.cs
+++ b/cs-project.Tests/Services/PricePolicyServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities.Pricing;
+using cs_project.Core.Interfaces;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class PricePolicyServiceTests
+{
+    private readonly IMapper _mapper;
+    public PricePolicyServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<IPricePolicyRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(new PricePolicy { Id = 1 });
+        var service = new PricePolicyService(repo.Object, _mapper);
+
+        var result = await service.GetByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<IPricePolicyRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync((PricePolicy?)null);
+        var service = new PricePolicyService(repo.Object, _mapper);
+
+        var result = await service.GetByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new PricePolicy { Id = 1 };
+        var repo = new Mock<IPricePolicyRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true).Verifiable();
+        var service = new PricePolicyService(repo.Object, _mapper);
+
+        var result = await service.DeleteAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/PricingServiceTests.cs
+++ b/cs-project.Tests/Services/PricingServiceTests.cs
@@ -1,0 +1,60 @@
+using cs_project.Core.Entities.Pricing;
+using cs_project.Core.Interfaces;
+using cs_project.Infrastructure.Services;
+using Moq;
+using static cs_project.Core.Entities.Enums;
+
+namespace cs_project.Tests.Services;
+
+public class PricingServiceTests
+{
+    [Fact]
+    public async Task RepriceStation_AddsPrices_WhenPolicyGeneratesPrice()
+    {
+        var fxRepo = new Mock<IExchangeRateRepository>();
+        var policyRepo = new Mock<IPricePolicyRepository>();
+        var costRepo = new Mock<ISupplierCostRepository>();
+        var priceRepo = new Mock<IStationFuelPriceRepository>();
+
+        fxRepo.Setup(r => r.GetLatestUsdToRonAsync(It.IsAny<CancellationToken>())).ReturnsAsync(5m);
+        policyRepo.Setup(r => r.GetActivePoliciesAsync(1, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PricePolicy> {
+                new() { Id = 1, FuelType = FuelType.Diesel, Method = PricingMethod.FlatUsd, BaseUsdPrice = 1m, MarginPct = 0m }
+            });
+        priceRepo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var service = new PricingService(fxRepo.Object, policyRepo.Object, costRepo.Object, priceRepo.Object);
+
+        var result = await service.RepriceStationAsync(1);
+
+        Assert.Single(result);
+        priceRepo.Verify(r => r.AddAsync(It.IsAny<StationFuelPrice>(), It.IsAny<CancellationToken>()), Times.Once);
+        priceRepo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RepriceStation_SkipsPolicy_WhenPriceNotComputed()
+    {
+        var fxRepo = new Mock<IExchangeRateRepository>();
+        var policyRepo = new Mock<IPricePolicyRepository>();
+        var costRepo = new Mock<ISupplierCostRepository>();
+        var priceRepo = new Mock<IStationFuelPriceRepository>();
+
+        fxRepo.Setup(r => r.GetLatestUsdToRonAsync(It.IsAny<CancellationToken>())).ReturnsAsync(5m);
+        policyRepo.Setup(r => r.GetActivePoliciesAsync(1, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PricePolicy> {
+                new() { Id = 1, FuelType = FuelType.Diesel, Method = PricingMethod.CostPlus, MarginPct = 0m }
+            });
+        costRepo.Setup(r => r.GetWACRonAsync(1, FuelType.Diesel, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((decimal?)null);
+        priceRepo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var service = new PricingService(fxRepo.Object, policyRepo.Object, costRepo.Object, priceRepo.Object);
+
+        var result = await service.RepriceStationAsync(1);
+
+        Assert.Empty(result);
+        priceRepo.Verify(r => r.AddAsync(It.IsAny<StationFuelPrice>(), It.IsAny<CancellationToken>()), Times.Never);
+        priceRepo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/SalesServiceTests.cs
+++ b/cs-project.Tests/Services/SalesServiceTests.cs
@@ -1,0 +1,45 @@
+using cs_project.Core.Entities;
+using cs_project.Core.Entities.Pricing;
+using cs_project.Core.Interfaces;
+using cs_project.Infrastructure.Data;
+using cs_project.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using static cs_project.Core.Entities.Enums;
+
+namespace cs_project.Tests.Services;
+
+public class SalesServiceTests
+{
+    [Fact]
+    public async Task CreateSale_CreatesTransaction_WhenValid()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("sales_success").Options;
+        using var db = new AppDbContext(options);
+        db.Stations.Add(new Station { Id = 1, Name = "S", Address = "A" });
+        db.Tanks.Add(new Tank { Id = 1, StationId = 1, FuelType = FuelType.Diesel });
+        db.Pumps.Add(new Pump { Id = 1, TankId = 1 });
+        await db.SaveChangesAsync();
+
+        var priceRepo = new Mock<IStationFuelPriceRepository>();
+        priceRepo.Setup(r => r.GetCurrentAsync(1, FuelType.Diesel, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StationFuelPrice { Id = 1, PriceRon = 5m });
+
+        var service = new SalesService(db, priceRepo.Object);
+        var trx = await service.CreateSaleAsync(1, 10m, CancellationToken.None);
+
+        Assert.Equal(10m, trx.Liters);
+        Assert.Equal(1, await db.CustomerTransactions.CountAsync());
+    }
+
+    [Fact]
+    public async Task CreateSale_Throws_WhenInvalidLiters()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("sales_fail").Options;
+        using var db = new AppDbContext(options);
+        var priceRepo = new Mock<IStationFuelPriceRepository>();
+        var service = new SalesService(db, priceRepo.Object);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => service.CreateSaleAsync(1, 0m, CancellationToken.None));
+    }
+}

--- a/cs-project.Tests/Services/ShiftEmployeeServiceTests.cs
+++ b/cs-project.Tests/Services/ShiftEmployeeServiceTests.cs
@@ -1,0 +1,57 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class ShiftEmployeeServiceTests
+{
+    private readonly IMapper _mapper;
+    public ShiftEmployeeServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddEmployee_ReturnsDto_WhenNew()
+    {
+        var repo = new Mock<IShiftEmployeeRepository>();
+        repo.Setup(r => r.GetByShiftAndEmployeeIdAsync(1, 2)).ReturnsAsync((ShiftEmployee?)null);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true);
+        var service = new ShiftEmployeeService(repo.Object, _mapper);
+
+        var result = await service.AddEmployeeToShiftAsync(1, 2);
+
+        Assert.NotNull(result);
+        repo.Verify(r => r.AddAsync(It.Is<ShiftEmployee>(se => se.ShiftId == 1 && se.EmployeeId == 2)), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddEmployee_ReturnsNull_WhenExists()
+    {
+        var repo = new Mock<IShiftEmployeeRepository>();
+        repo.Setup(r => r.GetByShiftAndEmployeeIdAsync(1, 2)).ReturnsAsync(new ShiftEmployee());
+        var service = new ShiftEmployeeService(repo.Object, _mapper);
+
+        var result = await service.AddEmployeeToShiftAsync(1, 2);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task RemoveEmployee_ReturnsFalse_WhenMissing()
+    {
+        var repo = new Mock<IShiftEmployeeRepository>();
+        repo.Setup(r => r.GetByShiftAndEmployeeIdAsync(1, 2)).ReturnsAsync((ShiftEmployee?)null);
+        var service = new ShiftEmployeeService(repo.Object, _mapper);
+
+        var result = await service.RemoveEmployeeFromShiftAsync(1, 2);
+
+        Assert.False(result);
+    }
+}

--- a/cs-project.Tests/Services/ShiftServiceTests.cs
+++ b/cs-project.Tests/Services/ShiftServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class ShiftServiceTests
+{
+    private readonly IMapper _mapper;
+    public ShiftServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<IShiftRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new Shift { Id = 1 });
+        var service = new ShiftService(repo.Object, _mapper);
+
+        var result = await service.GetShiftByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<IShiftRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((Shift?)null);
+        var service = new ShiftService(repo.Object, _mapper);
+
+        var result = await service.GetShiftByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new Shift { Id = 1 };
+        var repo = new Mock<IShiftRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var service = new ShiftService(repo.Object, _mapper);
+
+        var result = await service.DeleteShiftAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/StationFuelPriceServiceTests.cs
+++ b/cs-project.Tests/Services/StationFuelPriceServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities.Pricing;
+using cs_project.Core.Interfaces;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class StationFuelPriceServiceTests
+{
+    private readonly IMapper _mapper;
+    public StationFuelPriceServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<IStationFuelPriceRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(new StationFuelPrice { Id = 1 });
+        var service = new StationFuelPriceService(repo.Object, _mapper);
+
+        var result = await service.GetByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<IStationFuelPriceRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync((StationFuelPrice?)null);
+        var service = new StationFuelPriceService(repo.Object, _mapper);
+
+        var result = await service.GetByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new StationFuelPrice { Id = 1 };
+        var repo = new Mock<IStationFuelPriceRepository>();
+        repo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true).Verifiable();
+        var service = new StationFuelPriceService(repo.Object, _mapper);
+
+        var result = await service.DeleteAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/StationServiceTests.cs
+++ b/cs-project.Tests/Services/StationServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class StationServiceTests
+{
+    private readonly IMapper _mapper;
+    public StationServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<IStationRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new Station { Id = 1, Name="S", Address="A" });
+        var service = new StationService(repo.Object, _mapper);
+
+        var result = await service.GetStationByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<IStationRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((Station?)null);
+        var service = new StationService(repo.Object, _mapper);
+
+        var result = await service.GetStationByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new Station { Id = 1, Name="S", Address="A" };
+        var repo = new Mock<IStationRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var service = new StationService(repo.Object, _mapper);
+
+        var result = await service.DeleteStationAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/SupplierPaymentApplyServiceTests.cs
+++ b/cs-project.Tests/Services/SupplierPaymentApplyServiceTests.cs
@@ -1,0 +1,58 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Data;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class SupplierPaymentApplyServiceTests
+{
+    private readonly IMapper _mapper;
+    public SupplierPaymentApplyServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task CreateApply_Succeeds_WhenValid()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("apply_success").Options;
+        using var db = new AppDbContext(options);
+        db.SupplierPayments.Add(new SupplierPayment { Id = 1, SupplierId = 1, Amount = 100, Applies = new List<SupplierPaymentApply>() });
+        db.SupplierInvoices.Add(new SupplierInvoice { Id = 1, SupplierId = 1, Lines = new List<SupplierInvoiceLine>{ new(){ QuantityLiters = 100, UnitPrice = 1 } }, Applies = new List<SupplierPaymentApply>() });
+        await db.SaveChangesAsync();
+
+        var repo = new Mock<ISupplierPaymentApplyRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<SupplierPaymentApply>())).Returns(Task.CompletedTask);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true);
+        var service = new SupplierPaymentApplyService(repo.Object, db, _mapper);
+
+        var dto = new SupplierPaymentApplyCreateDTO { SupplierPaymentId = 1, SupplierInvoiceId = 1, AppliedAmount = 50 };
+        var result = await service.CreateSupplierPaymentApplyAsync(dto);
+
+        Assert.NotNull(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<SupplierPaymentApply>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateApply_Throws_WhenSupplierMismatch()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("apply_fail").Options;
+        using var db = new AppDbContext(options);
+        db.SupplierPayments.Add(new SupplierPayment { Id = 1, SupplierId = 1, Amount = 100, Applies = new List<SupplierPaymentApply>() });
+        db.SupplierInvoices.Add(new SupplierInvoice { Id = 1, SupplierId = 2, Lines = new List<SupplierInvoiceLine>{ new(){ QuantityLiters = 100, UnitPrice = 1 } }, Applies = new List<SupplierPaymentApply>() });
+        await db.SaveChangesAsync();
+
+        var repo = new Mock<ISupplierPaymentApplyRepository>();
+        var service = new SupplierPaymentApplyService(repo.Object, db, _mapper);
+        var dto = new SupplierPaymentApplyCreateDTO { SupplierPaymentId = 1, SupplierInvoiceId = 1, AppliedAmount = 50 };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.CreateSupplierPaymentApplyAsync(dto));
+    }
+}

--- a/cs-project.Tests/Services/SupplierPaymentServiceTests.cs
+++ b/cs-project.Tests/Services/SupplierPaymentServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class SupplierPaymentServiceTests
+{
+    private readonly IMapper _mapper;
+    public SupplierPaymentServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<ISupplierPaymentRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new SupplierPayment { Id = 1 });
+        var service = new SupplierPaymentService(repo.Object, _mapper);
+
+        var result = await service.GetSupplierPaymentByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<ISupplierPaymentRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((SupplierPayment?)null);
+        var service = new SupplierPaymentService(repo.Object, _mapper);
+
+        var result = await service.GetSupplierPaymentByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new SupplierPayment { Id = 1 };
+        var repo = new Mock<ISupplierPaymentRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var service = new SupplierPaymentService(repo.Object, _mapper);
+
+        var result = await service.DeleteSupplierPaymentAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+}

--- a/cs-project.Tests/Services/TankServiceTests.cs
+++ b/cs-project.Tests/Services/TankServiceTests.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using cs_project.Core.DTOs;
+using cs_project.Core.Entities;
+using cs_project.Infrastructure.Mapping;
+using cs_project.Infrastructure.Repositories;
+using cs_project.Infrastructure.Services;
+using Moq;
+
+namespace cs_project.Tests.Services;
+
+public class TankServiceTests
+{
+    private readonly IMapper _mapper;
+    public TankServiceTests()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsDto_WhenFound()
+    {
+        var repo = new Mock<ITankRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new Tank { Id = 1 });
+        var service = new TankService(repo.Object, _mapper);
+
+        var result = await service.GetTankByIdAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNull_WhenMissing()
+    {
+        var repo = new Mock<ITankRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((Tank?)null);
+        var service = new TankService(repo.Object, _mapper);
+
+        var result = await service.GetTankByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_CallsRepository_WhenFound()
+    {
+        var entity = new Tank { Id = 1 };
+        var repo = new Mock<ITankRepository>();
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(entity);
+        repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(true).Verifiable();
+        var service = new TankService(repo.Object, _mapper);
+
+        var result = await service.DeleteTankAsync(1);
+
+        Assert.True(result);
+        repo.Verify(r => r.Delete(entity), Times.Once);
+        repo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for AuditLog, CorrectionLog, CustomerTransaction, ExchangeRate, PricePolicy, Shift, ShiftEmployee, Pricing, StationFuelPrice, Station, Sales, SupplierPayment, SupplierPaymentApply and Tank services
- cover success and failure scenarios and verify repository interactions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5d6961e0832a8f0193bad7df77c5