### PR TITLE
Add validation tests for DTO validators

### DIFF
--- a/cs-project.Tests/Validators/AuditLogCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/AuditLogCreateDTOValidatorTests.cs
@@ -1,0 +1,48 @@
+using System;
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class AuditLogCreateDTOValidatorTests
+{
+    private readonly AuditLogCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new AuditLogCreateDTO
+        {
+            TableName = "Users",
+            RecordId = 1,
+            Operation = "Insert",
+            ModifiedBy = 1,
+            ModifiedAt = DateTimeOffset.UtcNow
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new AuditLogCreateDTO
+        {
+            TableName = "",
+            RecordId = 0,
+            Operation = "",
+            ModifiedBy = 0,
+            ModifiedAt = default
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "TableName" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "RecordId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Operation" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "ModifiedBy" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "ModifiedAt" && x.ErrorMessage.Contains("not be empty"));
+    }
+}

--- a/cs-project.Tests/Validators/CorrectionLogCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/CorrectionLogCreateDTOValidatorTests.cs
@@ -1,0 +1,58 @@
+using System;
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class CorrectionLogCreateDTOValidatorTests
+{
+    private readonly CorrectionLogCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new CorrectionLogCreateDTO
+        {
+            TargetTable = "Logs",
+            TargetId = 1,
+            Type = CorrectionType.Adjustment,
+            Reason = "Reason",
+            RequestedById = 1,
+            ApprovedById = 2,
+            RequestedAtUtc = DateTime.UtcNow,
+            ApprovedAtUtc = DateTime.UtcNow.AddHours(1)
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var now = DateTime.UtcNow;
+        var dto = new CorrectionLogCreateDTO
+        {
+            TargetTable = "",
+            TargetId = 0,
+            Type = (CorrectionType)(-1),
+            Reason = "",
+            RequestedById = 0,
+            ApprovedById = 0,
+            RequestedAtUtc = now,
+            ApprovedAtUtc = now
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "TargetTable" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "TargetId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Type" && x.ErrorMessage.Contains("'Type'"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Reason" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "RequestedById" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "ApprovedById" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "ApprovedAtUtc" && x.ErrorMessage.Contains("greater than"));
+    }
+}

--- a/cs-project.Tests/Validators/CustomerPaymentCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/CustomerPaymentCreateDTOValidatorTests.cs
@@ -1,0 +1,49 @@
+using System;
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class CustomerPaymentCreateDTOValidatorTests
+{
+    private readonly CustomerPaymentCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new CustomerPaymentCreateDTO
+        {
+            CustomerTransactionId = 1,
+            Method = PaymentMethod.Cash,
+            Amount = 10m,
+            AuthorizationCode = "AUTH",
+            ProcessedAtUtc = DateTime.UtcNow
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new CustomerPaymentCreateDTO
+        {
+            CustomerTransactionId = 0,
+            Method = (PaymentMethod)(-1),
+            Amount = -1m,
+            AuthorizationCode = new string('a', 101),
+            ProcessedAtUtc = default
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "CustomerTransactionId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Method" && x.ErrorMessage.Contains("range"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Amount" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "AuthorizationCode" && x.ErrorMessage.Contains("characters"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "ProcessedAtUtc" && x.ErrorMessage.Contains("not be empty"));
+    }
+}

--- a/cs-project.Tests/Validators/CustomerTransactionCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/CustomerTransactionCreateDTOValidatorTests.cs
@@ -1,0 +1,51 @@
+using System;
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class CustomerTransactionCreateDTOValidatorTests
+{
+    private readonly CustomerTransactionCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new CustomerTransactionCreateDTO
+        {
+            PumpId = 1,
+            StationFuelPriceId = 1,
+            Liters = 10m,
+            PricePerLiter = 5m,
+            TotalPrice = 50m,
+            TimestampUtc = DateTimeOffset.UtcNow
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new CustomerTransactionCreateDTO
+        {
+            PumpId = 0,
+            StationFuelPriceId = 0,
+            Liters = 0m,
+            PricePerLiter = -1m,
+            TotalPrice = -1m,
+            TimestampUtc = default
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "PumpId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "StationFuelPriceId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Liters" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "PricePerLiter" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "TotalPrice" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "TimestampUtc" && x.ErrorMessage.Contains("not be empty"));
+    }
+}

--- a/cs-project.Tests/Validators/EmployeeCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/EmployeeCreateDTOValidatorTests.cs
@@ -1,0 +1,49 @@
+using System;
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class EmployeeCreateDTOValidatorTests
+{
+    private readonly EmployeeCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new EmployeeCreateDTO
+        {
+            StationId = 1,
+            FirstName = "John",
+            LastName = "Doe",
+            Role = EmployeeRole.Cashier,
+            HireDateUtc = DateTime.UtcNow
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new EmployeeCreateDTO
+        {
+            StationId = 0,
+            FirstName = "",
+            LastName = "",
+            Role = (EmployeeRole)(-1),
+            HireDateUtc = default
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "StationId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "FirstName" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "LastName" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Role" && x.ErrorMessage.Contains("'Role'"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "HireDateUtc" && x.ErrorMessage.Contains("not be empty"));
+    }
+}

--- a/cs-project.Tests/Validators/ExchangeRateCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/ExchangeRateCreateDTOValidatorTests.cs
@@ -1,0 +1,48 @@
+using System;
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class ExchangeRateCreateDTOValidatorTests
+{
+    private readonly ExchangeRateCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new ExchangeRateCreateDTO
+        {
+            BaseCurrency = "USD",
+            QuoteCurrency = "RON",
+            Rate = 4.5m,
+            RetrievedAtUtc = DateTime.UtcNow,
+            Source = "ECB"
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new ExchangeRateCreateDTO
+        {
+            BaseCurrency = "US",
+            QuoteCurrency = "",
+            Rate = -1m,
+            RetrievedAtUtc = default,
+            Source = new string('a', 101)
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "BaseCurrency" && x.ErrorMessage.Contains("length"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "QuoteCurrency" && x.ErrorMessage.Contains("length"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Rate" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "RetrievedAtUtc" && x.ErrorMessage.Contains("not be empty"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Source" && x.ErrorMessage.Contains("characters"));
+    }
+}

--- a/cs-project.Tests/Validators/PricePolicyCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/PricePolicyCreateDTOValidatorTests.cs
@@ -1,0 +1,67 @@
+using System;
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class PricePolicyCreateDTOValidatorTests
+{
+    private readonly PricePolicyCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new PricePolicyCreateDTO
+        {
+            StationId = 1,
+            FuelType = FuelType.Petrol95,
+            Method = PricingMethod.FlatUsd,
+            BaseUsdPrice = 1m,
+            MarginPct = 10m,
+            MarginRon = 0m,
+            RoundingIncrement = 0.1m,
+            RoundingMode = RoundingMode.Round,
+            EffectiveFromUtc = DateTime.UtcNow,
+            EffectiveToUtc = DateTime.UtcNow.AddDays(1),
+            Priority = 1
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new PricePolicyCreateDTO
+        {
+            StationId = 0,
+            FuelType = (FuelType)(-1),
+            Method = (PricingMethod)(-1),
+            BaseUsdPrice = -1m,
+            MarginPct = -1m,
+            MarginRon = -1m,
+            RoundingIncrement = -1m,
+            RoundingMode = (RoundingMode)(-1),
+            EffectiveFromUtc = default,
+            EffectiveToUtc = DateTime.MinValue,
+            Priority = -1
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "StationId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "FuelType" && x.ErrorMessage.Contains("range"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Method" && x.ErrorMessage.Contains("range"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "BaseUsdPrice" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "MarginPct" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "MarginRon" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "RoundingIncrement" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "RoundingMode" && x.ErrorMessage.Contains("range"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "EffectiveFromUtc" && x.ErrorMessage.Contains("not be empty"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "EffectiveToUtc" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Priority" && x.ErrorMessage.Contains("greater than or equal"));
+    }
+}

--- a/cs-project.Tests/Validators/ShiftCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/ShiftCreateDTOValidatorTests.cs
@@ -1,0 +1,45 @@
+using System;
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class ShiftCreateDTOValidatorTests
+{
+    private readonly ShiftCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new ShiftCreateDTO
+        {
+            StationId = 1,
+            StartUtc = DateTime.UtcNow,
+            EndUtc = DateTime.UtcNow.AddHours(8),
+            TotalSalesAmount = 0m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new ShiftCreateDTO
+        {
+            StationId = 0,
+            StartUtc = default,
+            EndUtc = default,
+            TotalSalesAmount = -1m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "StationId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "StartUtc" && x.ErrorMessage.Contains("not be empty"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "EndUtc" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "TotalSalesAmount" && x.ErrorMessage.Contains("greater than or equal"));
+    }
+}

--- a/cs-project.Tests/Validators/ShiftEmployeeCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/ShiftEmployeeCreateDTOValidatorTests.cs
@@ -1,0 +1,38 @@
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class ShiftEmployeeCreateDTOValidatorTests
+{
+    private readonly ShiftEmployeeCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new ShiftEmployeeCreateDTO
+        {
+            ShiftId = 1,
+            EmployeeId = 1
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new ShiftEmployeeCreateDTO
+        {
+            ShiftId = 0,
+            EmployeeId = 0
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "ShiftId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "EmployeeId" && x.ErrorMessage.Contains("greater than"));
+    }
+}

--- a/cs-project.Tests/Validators/StationCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/StationCreateDTOValidatorTests.cs
@@ -1,0 +1,44 @@
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class StationCreateDTOValidatorTests
+{
+    private readonly StationCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new StationCreateDTO
+        {
+            Name = "Station",
+            Address = "Main St",
+            City = "City",
+            Country = "Country"
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new StationCreateDTO
+        {
+            Name = "",
+            Address = "",
+            City = new string('a', 101),
+            Country = new string('a', 101)
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "Name" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Address" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "City" && x.ErrorMessage.Contains("characters"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Country" && x.ErrorMessage.Contains("characters"));
+    }
+}

--- a/cs-project.Tests/Validators/StationFuelPriceCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/StationFuelPriceCreateDTOValidatorTests.cs
@@ -1,0 +1,61 @@
+using System;
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class StationFuelPriceCreateDTOValidatorTests
+{
+    private readonly StationFuelPriceCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new StationFuelPriceCreateDTO
+        {
+            StationId = 1,
+            FuelType = FuelType.Diesel,
+            PriceRon = 5m,
+            EffectiveFromUtc = DateTime.UtcNow,
+            EffectiveToUtc = DateTime.UtcNow.AddDays(1),
+            DerivedFromPolicyId = 1,
+            FxRateUsed = 4.5m,
+            CostRonUsed = 3m,
+            Reason = "Reason",
+            CreatedByEmployeeId = 1
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new StationFuelPriceCreateDTO
+        {
+            StationId = 0,
+            FuelType = (FuelType)(-1),
+            PriceRon = -1m,
+            EffectiveFromUtc = DateTime.UtcNow,
+            EffectiveToUtc = DateTime.UtcNow.AddMinutes(-1),
+            DerivedFromPolicyId = 0,
+            FxRateUsed = -1m,
+            CostRonUsed = -1m,
+            CreatedByEmployeeId = 0
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "StationId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "FuelType" && x.ErrorMessage.Contains("range"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "PriceRon" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "EffectiveToUtc" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "DerivedFromPolicyId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "FxRateUsed" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "CostRonUsed" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "CreatedByEmployeeId" && x.ErrorMessage.Contains("greater than"));
+    }
+}

--- a/cs-project.Tests/Validators/SupplierCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/SupplierCreateDTOValidatorTests.cs
@@ -1,0 +1,47 @@
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class SupplierCreateDTOValidatorTests
+{
+    private readonly SupplierCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new SupplierCreateDTO
+        {
+            CompanyName = "Company",
+            ContactPerson = "Person",
+            Phone = "+1234567890",
+            Email = "test@example.com",
+            TaxRegistrationNumber = "12345"
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new SupplierCreateDTO
+        {
+            CompanyName = "",
+            ContactPerson = new string('a', 101),
+            Phone = "invalid",
+            Email = "invalid",
+            TaxRegistrationNumber = new string('a', 51)
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "CompanyName" && x.ErrorMessage.Contains("required"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "ContactPerson" && x.ErrorMessage.Contains("characters"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Phone" && x.ErrorMessage.Contains("not valid"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Email" && x.ErrorMessage.Contains("email address"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "TaxRegistrationNumber" && x.ErrorMessage.Contains("characters"));
+    }
+}

--- a/cs-project.Tests/Validators/SupplierInvoiceCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/SupplierInvoiceCreateDTOValidatorTests.cs
@@ -1,0 +1,48 @@
+using System;
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class SupplierInvoiceCreateDTOValidatorTests
+{
+    private readonly SupplierInvoiceCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new SupplierInvoiceCreateDTO
+        {
+            SupplierId = 1,
+            StationId = 1,
+            DeliveryDateUtc = DateTime.UtcNow,
+            Currency = "USD",
+            FxToRon = 4.5m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new SupplierInvoiceCreateDTO
+        {
+            SupplierId = 0,
+            StationId = 0,
+            DeliveryDateUtc = default,
+            Currency = "US",
+            FxToRon = -1m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "SupplierId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "StationId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "DeliveryDateUtc" && x.ErrorMessage.Contains("not be empty"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Currency" && x.ErrorMessage.Contains("length"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "FxToRon" && x.ErrorMessage.Contains("greater than or equal"));
+    }
+}

--- a/cs-project.Tests/Validators/SupplierInvoiceLineCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/SupplierInvoiceLineCreateDTOValidatorTests.cs
@@ -1,0 +1,48 @@
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class SupplierInvoiceLineCreateDTOValidatorTests
+{
+    private readonly SupplierInvoiceLineCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new SupplierInvoiceLineCreateDTO
+        {
+            SupplierInvoiceId = 1,
+            TankId = 1,
+            FuelType = FuelType.Diesel,
+            QuantityLiters = 100m,
+            UnitPrice = 2m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new SupplierInvoiceLineCreateDTO
+        {
+            SupplierInvoiceId = 0,
+            TankId = 0,
+            FuelType = (FuelType)(-1),
+            QuantityLiters = 0m,
+            UnitPrice = -1m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "SupplierInvoiceId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "TankId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "FuelType" && x.ErrorMessage.Contains("range"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "QuantityLiters" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "UnitPrice" && x.ErrorMessage.Contains("greater than or equal"));
+    }
+}

--- a/cs-project.Tests/Validators/SupplierPaymentApplyCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/SupplierPaymentApplyCreateDTOValidatorTests.cs
@@ -1,0 +1,41 @@
+using cs_project.Core.DTOs;
+using Xunit;
+
+public class SupplierPaymentApplyCreateDTOValidatorTests
+{
+    private readonly SupplierPaymentApplyCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new SupplierPaymentApplyCreateDTO
+        {
+            SupplierPaymentId = 1,
+            SupplierInvoiceId = 1,
+            AppliedAmount = 50m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new SupplierPaymentApplyCreateDTO
+        {
+            SupplierPaymentId = 0,
+            SupplierInvoiceId = 0,
+            AppliedAmount = -1m
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "SupplierPaymentId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "SupplierInvoiceId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "AppliedAmount" && x.ErrorMessage.Contains("greater than or equal"));
+    }
+}

--- a/cs-project.Tests/Validators/SupplierPaymentCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/SupplierPaymentCreateDTOValidatorTests.cs
@@ -1,0 +1,46 @@
+using System;
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class SupplierPaymentCreateDTOValidatorTests
+{
+    private readonly SupplierPaymentCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new SupplierPaymentCreateDTO
+        {
+            SupplierId = 1,
+            Method = PaymentMethod.Cash,
+            Amount = 100m,
+            PaidAtUtc = DateTime.UtcNow
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new SupplierPaymentCreateDTO
+        {
+            SupplierId = 0,
+            Method = (PaymentMethod)(-1),
+            Amount = -1m,
+            PaidAtUtc = default
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "SupplierId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Method" && x.ErrorMessage.Contains("'Method'"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "Amount" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "PaidAtUtc" && x.ErrorMessage.Contains("not be empty"));
+    }
+}

--- a/cs-project.Tests/Validators/TankCreateDTOValidatorTests.cs
+++ b/cs-project.Tests/Validators/TankCreateDTOValidatorTests.cs
@@ -1,0 +1,49 @@
+using System;
+using cs_project.Core.DTOs;
+using static cs_project.Core.Entities.Enums;
+using Xunit;
+
+public class TankCreateDTOValidatorTests
+{
+    private readonly TankCreateDTOValidator _validator = new();
+
+    [Fact]
+    public void Should_Pass_When_Valid()
+    {
+        var dto = new TankCreateDTO
+        {
+            StationId = 1,
+            FuelType = FuelType.Petrol95,
+            CapacityLiters = 1000m,
+            CurrentVolumeLiters = 500m,
+            LastRefilledAtUtc = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Invalid()
+    {
+        var dto = new TankCreateDTO
+        {
+            StationId = 0,
+            FuelType = (FuelType)(-1),
+            CapacityLiters = -1m,
+            CurrentVolumeLiters = 2000m,
+            LastRefilledAtUtc = DateTime.UtcNow.AddDays(1)
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, x => x.PropertyName == "StationId" && x.ErrorMessage.Contains("greater than"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "FuelType" && x.ErrorMessage.Contains("range"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "CapacityLiters" && x.ErrorMessage.Contains("greater than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "CurrentVolumeLiters" && x.ErrorMessage.Contains("less than or equal"));
+        Assert.Contains(result.Errors, x => x.PropertyName == "LastRefilledAtUtc" && x.ErrorMessage.Contains("less than or equal"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering valid and invalid DTO cases for AuditLog, CorrectionLog, CustomerPayment, CustomerTransaction, Employee, ExchangeRate, PricePolicy, Shift, ShiftEmployee, Station, StationFuelPrice, Supplier, SupplierInvoice, SupplierInvoiceLine, SupplierPayment, SupplierPaymentApply, and Tank validators

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5d6ccfb8832aa0cd31a30211dfc6