### PR TITLE
Add sales listing, detail, update and delete endpoints

### DIFF
--- a/cs-project.Core/Interfaces/ISalesService.cs
+++ b/cs-project.Core/Interfaces/ISalesService.cs
@@ -5,5 +5,9 @@ namespace cs_project.Core.Interfaces
     public interface ISalesService
     {
         Task<CustomerTransaction> CreateSaleAsync(int pumpId, decimal liters, CancellationToken ct);
+        Task<IEnumerable<CustomerTransaction>> GetSalesAsync(CancellationToken ct);
+        Task<CustomerTransaction?> GetSaleByIdAsync(int id, CancellationToken ct);
+        Task<bool> UpdateSaleAsync(int id, int pumpId, decimal liters, CancellationToken ct);
+        Task<bool> DeleteSaleAsync(int id, CancellationToken ct);
     }
 }

--- a/cs-project.Tests/Controllers/SalesControllerTests.cs
+++ b/cs-project.Tests/Controllers/SalesControllerTests.cs
@@ -3,6 +3,7 @@ using cs_project.Core.DTOs;
 using cs_project.Core.Entities;
 using cs_project.Core.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 using System.Threading;
 using Moq;
 using Xunit;
@@ -34,5 +35,57 @@ public class SalesControllerTests
 
         var obj = Assert.IsType<ObjectResult>(result);
         Assert.IsType<ValidationProblemDetails>(obj.Value);
+    }
+
+    [Fact]
+    public async Task GetSales_ReturnsOk()
+    {
+        var service = new Mock<ISalesService>();
+        service.Setup(s => s.GetSalesAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(new List<CustomerTransaction>());
+        var controller = new SalesController(service.Object);
+
+        var result = await controller.GetSales(CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetSale_ReturnsNotFound_WhenMissing()
+    {
+        var service = new Mock<ISalesService>();
+        service.Setup(s => s.GetSaleByIdAsync(1, It.IsAny<CancellationToken>()))
+               .ReturnsAsync((CustomerTransaction?)null);
+        var controller = new SalesController(service.Object);
+
+        var result = await controller.GetSale(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateSale_ReturnsNoContent_WhenUpdated()
+    {
+        var service = new Mock<ISalesService>();
+        service.Setup(s => s.UpdateSaleAsync(1, 1, 1, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(true);
+        var controller = new SalesController(service.Object);
+
+        var result = await controller.UpdateSale(1, new CreateSaleDTO { PumpId = 1, Liters = 1 }, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteSale_ReturnsNoContent_WhenDeleted()
+    {
+        var service = new Mock<ISalesService>();
+        service.Setup(s => s.DeleteSaleAsync(1, It.IsAny<CancellationToken>()))
+               .ReturnsAsync(true);
+        var controller = new SalesController(service.Object);
+
+        var result = await controller.DeleteSale(1, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
     }
 }

--- a/cs-project/Controllers/SalesController.cs
+++ b/cs-project/Controllers/SalesController.cs
@@ -10,12 +10,41 @@ namespace cs_project.Controllers
     [Authorize]
     public class SalesController(ISalesService sales) : ControllerBase
     {
+        [HttpGet]
+        public async Task<IActionResult> GetSales(CancellationToken ct)
+        {
+            var list = await sales.GetSalesAsync(ct);
+            return Ok(list);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetSale(int id, CancellationToken ct)
+        {
+            var trx = await sales.GetSaleByIdAsync(id, ct);
+            return trx is null ? NotFound() : Ok(trx);
+        }
+
         [HttpPost]
         public async Task<IActionResult> CreateSale([FromBody] CreateSaleDTO dto, CancellationToken ct)
         {
             if (!ModelState.IsValid) return ValidationProblem(ModelState);
             var trx = await sales.CreateSaleAsync(dto.PumpId, dto.Liters, ct);
             return Ok(trx);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateSale(int id, [FromBody] CreateSaleDTO dto, CancellationToken ct)
+        {
+            if (!ModelState.IsValid) return ValidationProblem(ModelState);
+            var updated = await sales.UpdateSaleAsync(id, dto.PumpId, dto.Liters, ct);
+            return updated ? NoContent() : NotFound();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteSale(int id, CancellationToken ct)
+        {
+            var deleted = await sales.DeleteSaleAsync(id, ct);
+            return deleted ? NoContent() : NotFound();
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose GET, PUT and DELETE endpoints for sales
- extend ISalesService and SalesService for listing, editing and removing sales
- test coverage for new service and controller operations
 