### PR TITLE
refactor: rely on automatic model validation

### DIFF
--- a/cs-project.Tests/Controllers/SalesControllerTests.cs
+++ b/cs-project.Tests/Controllers/SalesControllerTests.cs
@@ -25,19 +25,6 @@ public class SalesControllerTests
     }
 
     [Fact]
-    public async Task CreateSale_ReturnsValidationProblem_WhenInvalid()
-    {
-        var service = new Mock<ISalesService>();
-        var controller = new SalesController(service.Object);
-        controller.ModelState.AddModelError("PumpId", "Required");
-
-        var result = await controller.CreateSale(new CreateSaleDTO(), CancellationToken.None);
-
-        var obj = Assert.IsType<ObjectResult>(result);
-        Assert.IsType<ValidationProblemDetails>(obj.Value);
-    }
-
-    [Fact]
     public async Task GetSales_ReturnsOk()
     {
         var service = new Mock<ISalesService>();

--- a/cs-project/Controllers/SalesController.cs
+++ b/cs-project/Controllers/SalesController.cs
@@ -27,7 +27,6 @@ namespace cs_project.Controllers
         [HttpPost]
         public async Task<IActionResult> CreateSale([FromBody] CreateSaleDTO dto, CancellationToken ct)
         {
-            if (!ModelState.IsValid) return ValidationProblem(ModelState);
             var trx = await sales.CreateSaleAsync(dto.PumpId, dto.Liters, ct);
             return Ok(trx);
         }
@@ -35,7 +34,6 @@ namespace cs_project.Controllers
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateSale(int id, [FromBody] CreateSaleDTO dto, CancellationToken ct)
         {
-            if (!ModelState.IsValid) return ValidationProblem(ModelState);
             var updated = await sales.UpdateSaleAsync(id, dto.PumpId, dto.Liters, ct);
             return updated ? NoContent() : NotFound();
         }


### PR DESCRIPTION
## Summary
- rely on [ApiController] automatic validation by removing manual ModelState checks in sales endpoints
- align unit tests with automatic validation behavior

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ac6b4a6070832a9e7ec2199394a47f