### PR TITLE
Replace ToLower.Contains with EF Like and add collations

### DIFF
--- a/cs-project.Infrastructure/Data/AppDbContext.cs
+++ b/cs-project.Infrastructure/Data/AppDbContext.cs
@@ -72,8 +72,16 @@ namespace cs_project.Infrastructure.Data
             // ---------- Station ----------
             model.Entity<Station>(e =>
             {
-                e.Property(p => p.Name).HasMaxLength(150).IsRequired();
-                e.Property(p => p.Address).HasMaxLength(250).IsRequired();
+                e.Property(p => p.Name).HasMaxLength(150).IsRequired()
+                    .UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(p => p.Address).HasMaxLength(250).IsRequired()
+                    .UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(p => p.City).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(p => p.Country).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.HasIndex(p => p.Name);
+                e.HasIndex(p => p.Address);
+                e.HasIndex(p => p.City);
+                e.HasIndex(p => p.Country);
             });
 
             // ---------- Tank ----------
@@ -100,6 +108,10 @@ namespace cs_project.Infrastructure.Data
             {
                 e.HasOne(emp => emp.Station).WithMany(st => st.Employees).HasForeignKey(emp => emp.StationId);
                 e.Property(emp => emp.Role).HasConversion<int>();
+                e.Property(emp => emp.FirstName).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(emp => emp.LastName).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.HasIndex(emp => emp.FirstName);
+                e.HasIndex(emp => emp.LastName);
             });
 
             // ---------- Shift / ShiftEmployee (bridge) ----------
@@ -161,7 +173,17 @@ namespace cs_project.Infrastructure.Data
             // ---------- Supplier ----------
             model.Entity<Supplier>(e =>
             {
-                e.Property(s => s.CompanyName).HasMaxLength(200).IsRequired();
+                e.Property(s => s.CompanyName).HasMaxLength(200).IsRequired()
+                    .UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(s => s.ContactPerson).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(s => s.Phone).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(s => s.Email).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(s => s.TaxRegistrationNumber).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.HasIndex(s => s.CompanyName);
+                e.HasIndex(s => s.ContactPerson);
+                e.HasIndex(s => s.Phone);
+                e.HasIndex(s => s.Email);
+                e.HasIndex(s => s.TaxRegistrationNumber);
             });
 
             // ---------- SupplierInvoice (TEMPORAL) ----------
@@ -287,14 +309,22 @@ namespace cs_project.Infrastructure.Data
                     .OnDelete(DeleteBehavior.Restrict);
                 e.HasOne(c => c.ApprovedBy).WithMany().HasForeignKey(c => c.ApprovedById)
                     .OnDelete(DeleteBehavior.Restrict);
+                e.Property(c => c.TargetTable).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(c => c.Reason).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(c => c.Type).HasConversion<int>();
                 e.HasIndex(c => new { c.TargetTable, c.TargetId });
+                e.HasIndex(c => c.Reason);
             });
 
             // ---------- AuditLog (app-level log) ----------
             model.Entity<AuditLog>(e =>
             {
+                e.Property(a => a.TableName).UseCollation("SQL_Latin1_General_CP1_CI_AS");
+                e.Property(a => a.Operation).UseCollation("SQL_Latin1_General_CP1_CI_AS");
                 e.HasIndex(a => a.ModifiedAt);
                 e.HasIndex(a => a.CorrelationId);
+                e.HasIndex(a => a.TableName);
+                e.HasIndex(a => a.Operation);
             });
         }
     }

--- a/cs-project.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/cs-project.Infrastructure/Repositories/AuditLogRepository.cs
@@ -20,11 +20,11 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                var term = query.SearchTerm.ToLower();
+                var term = $"%{query.SearchTerm}%";
                 logs = logs.Where(l =>
-                    l.TableName.ToLower().Contains(term) ||
-                    l.Operation.ToLower().Contains(term) ||
-                    l.CorrelationId.ToString().ToLower().Contains(term));
+                    EF.Functions.Like(l.TableName, term) ||
+                    EF.Functions.Like(l.Operation, term) ||
+                    EF.Functions.Like(l.CorrelationId.ToString(), term));
             }
 
             logs = query.SortBy?.ToLower() switch

--- a/cs-project.Infrastructure/Repositories/CorrectionLogRepository.cs
+++ b/cs-project.Infrastructure/Repositories/CorrectionLogRepository.cs
@@ -20,11 +20,11 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                var term = query.SearchTerm.ToLower();
+                var term = $"%{query.SearchTerm}%";
                 logs = logs.Where(l =>
-                    l.TargetTable.ToLower().Contains(term) ||
-                    l.Reason.ToLower().Contains(term) ||
-                    l.Type.ToString().ToLower().Contains(term));
+                    EF.Functions.Like(l.TargetTable, term) ||
+                    EF.Functions.Like(l.Reason, term) ||
+                    EF.Functions.Like(l.Type.ToString(), term));
             }
 
             logs = query.SortBy?.ToLower() switch

--- a/cs-project.Infrastructure/Repositories/EmployeeRepository.cs
+++ b/cs-project.Infrastructure/Repositories/EmployeeRepository.cs
@@ -22,12 +22,12 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                string term = query.SearchTerm.ToLower();
+                string term = $"%{query.SearchTerm}%";
                 employees = employees.Where(e =>
-                    e.FirstName.ToLower().Contains(term) ||
-                    e.LastName.ToLower().Contains(term) ||
-                    e.Role.ToString().ToLower().Contains(term) ||
-                    (e.Station != null && e.Station.Name.ToLower().Contains(term)));
+                    EF.Functions.Like(e.FirstName, term) ||
+                    EF.Functions.Like(e.LastName, term) ||
+                    EF.Functions.Like(e.Role.ToString(), term) ||
+                    (e.Station != null && EF.Functions.Like(e.Station.Name, term)));
             }
 
             employees = query.SortBy?.ToLower() switch

--- a/cs-project.Infrastructure/Repositories/PumpRepository.cs
+++ b/cs-project.Infrastructure/Repositories/PumpRepository.cs
@@ -19,10 +19,10 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                string term = query.SearchTerm.ToLower();
+                string term = $"%{query.SearchTerm}%";
                 pumps = pumps.Where(p =>
-                    p.Tank.FuelType.ToString().ToLower().Contains(term) ||
-                    p.Status.ToString().ToLower().Contains(term));
+                    EF.Functions.Like(p.Tank.FuelType.ToString(), term) ||
+                    EF.Functions.Like(p.Status.ToString(), term));
             }
 
             pumps = query.SortBy?.ToLower() switch

--- a/cs-project.Infrastructure/Repositories/ShiftRepository.cs
+++ b/cs-project.Infrastructure/Repositories/ShiftRepository.cs
@@ -22,10 +22,10 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                string term = query.SearchTerm.ToLower();
+                string term = $"%{query.SearchTerm}%";
                 shifts = shifts.Where(s =>
-                    s.Station.Name.ToLower().Contains(term) ||
-                    s.StationId.ToString().Contains(term));
+                    EF.Functions.Like(s.Station.Name, term) ||
+                    EF.Functions.Like(s.StationId.ToString(), term));
             }
 
             shifts = query.SortBy?.ToLower() switch

--- a/cs-project.Infrastructure/Repositories/StationRepository.cs
+++ b/cs-project.Infrastructure/Repositories/StationRepository.cs
@@ -23,12 +23,12 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                var term = query.SearchTerm.ToLower();
+                var term = $"%{query.SearchTerm}%";
                 stations = stations.Where(s =>
-                    s.Name.ToLower().Contains(term) ||
-                    s.Address.ToLower().Contains(term) ||
-                    (s.City != null && s.City.ToLower().Contains(term)) ||
-                    (s.Country != null && s.Country.ToLower().Contains(term)));
+                    EF.Functions.Like(s.Name, term) ||
+                    EF.Functions.Like(s.Address, term) ||
+                    (s.City != null && EF.Functions.Like(s.City, term)) ||
+                    (s.Country != null && EF.Functions.Like(s.Country, term)));
             }
 
             stations = query.SortBy?.ToLower() switch

--- a/cs-project.Infrastructure/Repositories/SupplierRepository.cs
+++ b/cs-project.Infrastructure/Repositories/SupplierRepository.cs
@@ -20,13 +20,13 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                string term = query.SearchTerm.ToLower();
+                string term = $"%{query.SearchTerm}%";
                 suppliers = suppliers.Where(s =>
-                    s.CompanyName.ToLower().Contains(term) ||
-                    (s.ContactPerson != null && s.ContactPerson.ToLower().Contains(term)) ||
-                    (s.Phone != null && s.Phone.ToLower().Contains(term)) ||
-                    (s.Email != null && s.Email.ToLower().Contains(term)) ||
-                    (s.TaxRegistrationNumber != null && s.TaxRegistrationNumber.ToLower().Contains(term)));
+                    EF.Functions.Like(s.CompanyName, term) ||
+                    (s.ContactPerson != null && EF.Functions.Like(s.ContactPerson, term)) ||
+                    (s.Phone != null && EF.Functions.Like(s.Phone, term)) ||
+                    (s.Email != null && EF.Functions.Like(s.Email, term)) ||
+                    (s.TaxRegistrationNumber != null && EF.Functions.Like(s.TaxRegistrationNumber, term)));
             }
 
             suppliers = query.SortBy?.ToLower() switch

--- a/cs-project.Infrastructure/Repositories/TankRepository.cs
+++ b/cs-project.Infrastructure/Repositories/TankRepository.cs
@@ -19,10 +19,10 @@ namespace cs_project.Infrastructure.Repositories
 
             if (!string.IsNullOrWhiteSpace(query.SearchTerm))
             {
-                string term = query.SearchTerm.ToLower();
+                string term = $"%{query.SearchTerm}%";
                 tanks = tanks.Where(t =>
-                    t.FuelType.ToString().ToLower().Contains(term) ||
-                    t.Station.Name.ToLower().Contains(term));
+                    EF.Functions.Like(t.FuelType.ToString(), term) ||
+                    EF.Functions.Like(t.Station.Name, term));
             }
 
             tanks = query.SortBy?.ToLower() switch


### PR DESCRIPTION
## Summary
- Replace string ToLower().Contains calls with EF.Functions.Like for better search translation
- Configure case-insensitive collations and indexes on frequently searched columns