### PR TITLE
Use typed Jwt options

### DIFF
--- a/cs-project.Tests/Controllers/AccountControllerTests.cs
+++ b/cs-project.Tests/Controllers/AccountControllerTests.cs
@@ -3,25 +3,23 @@ using cs_project.Core.DTOs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
+using Microsoft.Extensions.Options;
 using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 using Moq;
 using Xunit;
+using cs_project.Options;
 
 namespace cs_project.Tests.Controllers;
 
 public class AccountControllerTests
 {
-    private static IConfiguration BuildConfig() => new ConfigurationBuilder()
-        .AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            {"Jwt:Key", "01234567890123456789012345678901"},
-            {"Jwt:Issuer", "issuer"},
-            {"Jwt:Audience", "audience"}
-        })
-        .Build();
+    private static IOptions<JwtOptions> BuildOptions() => Microsoft.Extensions.Options.Options.Create(new JwtOptions
+    {
+        Key = "01234567890123456789012345678901",
+        Issuer = "issuer",
+        Audience = "audience"
+    });
 
     private static Mock<UserManager<IdentityUser>> MockUserManager()
     {
@@ -41,7 +39,7 @@ public class AccountControllerTests
         var um = MockUserManager();
         var sm = MockSignInManager(um.Object);
         um.Setup(u => u.CreateAsync(It.IsAny<IdentityUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
-        var controller = new AccountController(um.Object, sm.Object, BuildConfig(), Mock.Of<ILogger<AccountController>>());
+        var controller = new AccountController(um.Object, sm.Object, BuildOptions(), Mock.Of<ILogger<AccountController>>());
 
         var result = await controller.Register(new RegisterDTO { UserName = "u", Email = "e", Password = "p" });
 
@@ -54,7 +52,7 @@ public class AccountControllerTests
         var um = MockUserManager();
         var sm = MockSignInManager(um.Object);
         um.Setup(u => u.CreateAsync(It.IsAny<IdentityUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
-        var controller = new AccountController(um.Object, sm.Object, BuildConfig(), Mock.Of<ILogger<AccountController>>());
+        var controller = new AccountController(um.Object, sm.Object, BuildOptions(), Mock.Of<ILogger<AccountController>>());
 
         var result = await controller.Register(new RegisterDTO { UserName = "u", Email = "e", Password = "p" });
 
@@ -69,7 +67,7 @@ public class AccountControllerTests
         um.Setup(u => u.FindByNameAsync("u")).ReturnsAsync(user);
         var sm = MockSignInManager(um.Object);
         sm.Setup(s => s.PasswordSignInAsync(user, "p", false, true)).ReturnsAsync(SignInResult.Success);
-        var controller = new AccountController(um.Object, sm.Object, BuildConfig(), Mock.Of<ILogger<AccountController>>());
+        var controller = new AccountController(um.Object, sm.Object, BuildOptions(), Mock.Of<ILogger<AccountController>>());
 
         var result = await controller.Login(new LoginDTO { UserName = "u", Password = "p" });
 
@@ -86,7 +84,7 @@ public class AccountControllerTests
         um.Setup(u => u.FindByNameAsync("u")).ReturnsAsync(user);
         var sm = MockSignInManager(um.Object);
         sm.Setup(s => s.PasswordSignInAsync(user, "p", false, true)).ReturnsAsync(SignInResult.Failed);
-        var controller = new AccountController(um.Object, sm.Object, BuildConfig(), Mock.Of<ILogger<AccountController>>());
+        var controller = new AccountController(um.Object, sm.Object, BuildOptions(), Mock.Of<ILogger<AccountController>>());
 
         var result = await controller.Login(new LoginDTO { UserName = "u", Password = "p" });
 

--- a/cs-project/Controllers/AccountController.cs
+++ b/cs-project/Controllers/AccountController.cs
@@ -1,111 +1,115 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using cs_project.Core.DTOs;
+using cs_project.Options;
 
-namespace cs_project.Controllers
+namespace cs_project.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AccountController(
+    UserManager<IdentityUser> userManager,
+    SignInManager<IdentityUser> signInManager,
+    IOptions<JwtOptions> jwtOptions,
+    ILogger<AccountController> logger) : ControllerBase
 {
-    [ApiController]
-    [Route("api/[controller]")]
-    public class AccountController(UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager, IConfiguration configuration, ILogger<AccountController> logger) : ControllerBase
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] RegisterDTO model)
     {
-        [HttpPost("register")]
-        public async Task<IActionResult> Register([FromBody] RegisterDTO model)
+        var user = new IdentityUser { UserName = model.UserName, Email = model.Email };
+        var result = await userManager.CreateAsync(user, model.Password);
+
+        if (result.Succeeded)
+            return Ok("User registered.");
+        return BadRequest(result.Errors);
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginDTO model)
+    {
+        var user = await userManager.FindByNameAsync(model.UserName);
+        if (user == null) return Unauthorized("Invalid credentials.");
+
+        var result = await signInManager.PasswordSignInAsync(user, model.Password, false, lockoutOnFailure: true);
+        if (result.IsLockedOut) return BadRequest("Account is temporarily locked. Try again later.");
+        if (!result.Succeeded) return Unauthorized("Invalid credentials.");
+
+        var claims = new[]
         {
-            var user = new IdentityUser { UserName = model.UserName, Email = model.Email };
-            var result = await userManager.CreateAsync(user, model.Password);
+            new Claim(JwtRegisteredClaimNames.Sub, user.Id ?? string.Empty),
+            new Claim(JwtRegisteredClaimNames.UniqueName, user.UserName ?? string.Empty),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
 
-            if (result.Succeeded)
-                return Ok("User registered.");
-            return BadRequest(result.Errors);
-        }
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.Value.Key));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
-        [HttpPost("login")]
-        public async Task<IActionResult> Login(LoginDTO model)
+        var token = new JwtSecurityToken(
+            issuer: jwtOptions.Value.Issuer,
+            audience: jwtOptions.Value.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(2),
+            signingCredentials: creds);
+
+        var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
+        logger.LogInformation("Issuer: {Issuer}", jwtOptions.Value.Issuer);
+        logger.LogInformation("Audience: {Audience}", jwtOptions.Value.Audience);
+
+        return Ok(new { token = tokenString });
+    }
+
+    [Authorize]
+    [HttpGet]
+    public async Task<ActionResult<UserProfileDTO>> GetCurrentUser()
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
+
+        return Ok(new UserProfileDTO
         {
-            var user = await userManager.FindByNameAsync(model.UserName);
-            if (user == null) return Unauthorized("Invalid credentials.");
+            UserName = user.UserName ?? string.Empty,
+            Email = user.Email ?? string.Empty
+        });
+    }
 
-            var result = await signInManager.PasswordSignInAsync(user, model.Password, false, lockoutOnFailure: true);
-            if (result.IsLockedOut) return BadRequest("Account is temporarily locked. Try again later.");
-            if (!result.Succeeded) return Unauthorized("Invalid credentials.");
+    [Authorize]
+    [HttpPut]
+    public async Task<ActionResult<UserProfileDTO>> UpdateProfile([FromBody] UserProfileUpdateDTO updateDto)
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
 
-            var claims = new[]
-            {
-                new Claim(JwtRegisteredClaimNames.Sub, user.Id ?? string.Empty),
-                new Claim(JwtRegisteredClaimNames.UniqueName, user.UserName ?? string.Empty),
-                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
-            };
+        if (!string.IsNullOrWhiteSpace(updateDto.UserName)) user.UserName = updateDto.UserName;
+        if (!string.IsNullOrWhiteSpace(updateDto.Email)) user.Email = updateDto.Email;
 
-            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
-                configuration["Jwt:Key"] ?? throw new Exception("JWT key not configured")));
-            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var result = await userManager.UpdateAsync(user);
+        if (!result.Succeeded) return BadRequest(result.Errors);
 
-            var token = new JwtSecurityToken(
-                issuer: configuration["Jwt:Issuer"],
-                audience: configuration["Jwt:Audience"],
-                claims: claims,
-                expires: DateTime.UtcNow.AddHours(2),
-                signingCredentials: creds);
-
-            var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
-            logger.LogInformation("Issuer: {Issuer}", configuration["Jwt:Issuer"]);
-            logger.LogInformation("Audience: {Audience}", configuration["Jwt:Audience"]);
-
-            return Ok(new { token = tokenString });
-        }
-
-        [Authorize]
-        [HttpGet]
-        public async Task<ActionResult<UserProfileDTO>> GetCurrentUser()
+        return Ok(new UserProfileDTO
         {
-            var user = await userManager.GetUserAsync(User);
-            if (user == null) return NotFound();
+            UserName = user.UserName ?? string.Empty,
+            Email = user.Email ?? string.Empty
+        });
+    }
 
-            return Ok(new UserProfileDTO
-            {
-                UserName = user.UserName ?? string.Empty,
-                Email = user.Email ?? string.Empty
-            });
-        }
+    [Authorize]
+    [HttpDelete]
+    public async Task<IActionResult> DeleteAccount()
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
 
-        [Authorize]
-        [HttpPut]
-        public async Task<ActionResult<UserProfileDTO>> UpdateProfile([FromBody] UserProfileUpdateDTO updateDto)
-        {
-            var user = await userManager.GetUserAsync(User);
-            if (user == null) return NotFound();
+        var result = await userManager.DeleteAsync(user);
+        if (!result.Succeeded) return BadRequest(result.Errors);
 
-            if (!string.IsNullOrWhiteSpace(updateDto.UserName)) user.UserName = updateDto.UserName;
-            if (!string.IsNullOrWhiteSpace(updateDto.Email)) user.Email = updateDto.Email;
-
-            var result = await userManager.UpdateAsync(user);
-            if (!result.Succeeded) return BadRequest(result.Errors);
-
-            return Ok(new UserProfileDTO
-            {
-                UserName = user.UserName ?? string.Empty,
-                Email = user.Email ?? string.Empty
-            });
-        }
-
-        [Authorize]
-        [HttpDelete]
-        public async Task<IActionResult> DeleteAccount()
-        {
-            var user = await userManager.GetUserAsync(User);
-            if (user == null) return NotFound();
-
-            var result = await userManager.DeleteAsync(user);
-            if (!result.Succeeded) return BadRequest(result.Errors);
-
-            return NoContent();
-        }
-
+        return NoContent();
     }
 }
+

--- a/cs-project/Options/JwtOptions.cs
+++ b/cs-project/Options/JwtOptions.cs
@@ -1,10 +1,16 @@
-﻿namespace cs_project.Options
-{
-    public class JwtOptions
-    {
-        public required string Key { get; set; }
-        public required string Issuer { get; set; }
-        public required string Audience { get; set; }
+using System.ComponentModel.DataAnnotations;
 
-    }
+namespace cs_project.Options;
+
+public class JwtOptions
+{
+    [Required]
+    public required string Key { get; set; }
+
+    [Required]
+    public required string Issuer { get; set; }
+
+    [Required]
+    public required string Audience { get; set; }
 }
+


### PR DESCRIPTION
## Summary
- add data-annotated `JwtOptions` and register via `AddOptions` with validation
- switch authentication and controllers to depend on `IOptions<JwtOptions>`
- update tests for options-based configuration

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7e3213fc832a91613415a31f0d48