### PR TITLE
Use secrets for JWT configuration

### DIFF
--- a/k8s/api.yml
+++ b/k8s/api.yml
@@ -27,18 +27,27 @@ spec:
   
         env:
         - name: ASPNETCORE_ENVIRONMENT
-          value: Development
+          value: Production
         - name: ConnectionStrings__DefaultConnection
           valueFrom:
             secretKeyRef:
               name: api-conn
               key: DefaultConnection
         - name: Jwt__Key
-          value: "super-secret"           # you can move these to secrets too
+          valueFrom:
+            secretKeyRef:
+              name: jwt-secret
+              key: Jwt__Key
         - name: Jwt__Issuer
-          value: "cs-project-api"
+          valueFrom:
+            secretKeyRef:
+              name: jwt-secret
+              key: Jwt__Issuer
         - name: Jwt__Audience
-          value: "cs-project-client"
+          valueFrom:
+            secretKeyRef:
+              name: jwt-secret
+              key: Jwt__Audience
         readinessProbe:
           httpGet:
             path: /health

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -19,15 +19,24 @@ spec:
         - containerPort: 8080
         env:
         - name: ASPNETCORE_ENVIRONMENT
-          value: Development #change after deployment!
+          value: Production
         - name: ConnectionStrings__DefaultConnection
           value: "Server=sqldata,1433;Database=csproject;User ID=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"
         - name: Jwt__Key
-          value: "super-secret"
+          valueFrom:
+            secretKeyRef:
+              name: jwt-secret
+              key: Jwt__Key
         - name: Jwt__Issuer
-          value: "cs-project-api"
+          valueFrom:
+            secretKeyRef:
+              name: jwt-secret
+              key: Jwt__Issuer
         - name: Jwt__Audience
-          value: "cs-project-client"
+          valueFrom:
+            secretKeyRef:
+              name: jwt-secret
+              key: Jwt__Audience
 
 ---
 apiVersion: v1

--- a/k8s/jwt-secret.yml
+++ b/k8s/jwt-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jwt-secret
+type: Opaque
+stringData:
+  Jwt__Key: super-secret
+  Jwt__Issuer: cs-project-api
+  Jwt__Audience: cs-project-client


### PR DESCRIPTION
## Summary
- define `jwt-secret` storing JWT key, issuer and audience
- load JWT settings from Kubernetes secret
- default all manifests to `ASPNETCORE_ENVIRONMENT=Production`