### PR TITLE
Use dedicated SQL login for default connection

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/ahendest/cs-project-api
     environment:
       ASPNETCORE_ENVIRONMENT: Development #change after deployment!
-      ConnectionStrings__DefaultConnection: "Server=sqldata,1433;Database=csproject;User ID=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"
+      ConnectionStrings__DefaultConnection: "Server=sqldata,1433;Database=csproject;User ID=csapp;Password=${CSAPP_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"
       Jwt__Key: ${JWT_KEY}
       Jwt__Issuer: ${JWT_ISSUER}
       Jwt__Audience: ${JWT_AUDIENCE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       ASPNETCORE_URLS: http://+:8080
       ASPNETCORE_ENVIRONMENT: Development
       # EF Core uses this; Program.cs reads "DefaultConnection"
-      ConnectionStrings__DefaultConnection: "Server=sqldata,1433;Database=csproject;User ID=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"
+      ConnectionStrings__DefaultConnection: "Server=sqldata,1433;Database=csproject;User ID=csapp;Password=${CSAPP_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"
       Jwt__Key: ${JWT_KEY}
       Jwt__Issuer: ${JWT_ISSUER}
       Jwt__Audience: ${JWT_AUDIENCE}

--- a/k8s/api-secret.yml
+++ b/k8s/api-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-conn
+  labels:
+    app: cs-project-api
+type: Opaque
+stringData:
+  DefaultConnection: "Server=sqldata,1433;Database=csproject;User ID=csapp;Password=${CSAPP_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -21,7 +21,7 @@ spec:
         - name: ASPNETCORE_ENVIRONMENT
           value: Development #change after deployment!
         - name: ConnectionStrings__DefaultConnection
-          value: "Server=sqldata,1433;Database=csproject;User ID=sa;Password=${SA_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"
+          value: "Server=sqldata,1433;Database=csproject;User ID=csapp;Password=${CSAPP_PASSWORD};TrustServerCertificate=true;MultipleActiveResultSets=true"
         - name: Jwt__Key
           value: "super-secret"
         - name: Jwt__Issuer

--- a/sql/create-app-login.sql
+++ b/sql/create-app-login.sql
@@ -1,0 +1,17 @@
+-- Creates a dedicated SQL login for the application with minimal permissions.
+-- Usage:
+--   sqlcmd -S <server> -U sa -P <sa_password> -i create-app-login.sql -v APP_DB_PASSWORD="StrongPassword!1"
+
+IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = 'csapp')
+BEGIN
+    CREATE LOGIN csapp WITH PASSWORD = '$(APP_DB_PASSWORD)';
+END
+GO
+USE csproject;
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = 'csapp')
+BEGIN
+    CREATE USER csapp FOR LOGIN csapp;
+    ALTER ROLE db_datareader ADD MEMBER csapp;
+    ALTER ROLE db_datawriter ADD MEMBER csapp;
+END
+GO


### PR DESCRIPTION
## Summary
- add script to create `csapp` SQL login with minimal permissions
- point Docker and Kubernetes manifests at the new login
- provide K8s secret manifest for the updated connection string